### PR TITLE
Add unified CMake build with core library, plugins, and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/build/
+/.vs/
+/.vscode/
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(lpmd2 VERSION 0.1.0 LANGUAGES CXX)
+
+# Organize build outputs in predictable locations
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+add_subdirectory(liblpmd)
+add_subdirectory(plugins)
+add_subdirectory(lpmd)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # lpmd2
+
+A modernized CMake build that combines the core `liblpmd` library, runtime plugins, and the `lpmd` command line executable into a single project. The reorganisation makes it easy to build all components together and experiment with a simple molecular dynamics workflow.
+
+## Building
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+The executable is placed in `build/bin/lpmd` and plugins in `build/lib`.
+
+## Running
+
+Run the simulator and let it locate the default plugin automatically:
+
+```bash
+./build/bin/lpmd
+```
+
+You can also specify a plugin explicitly:
+
+```bash
+./build/bin/lpmd /path/to/plugin
+```
+
+## Project layout
+
+- `liblpmd/` – Core simulation primitives and the plugin loader.
+- `plugins/` – Sample plugins implementing `lpmd::ForceField`.
+- `lpmd/` – Command line executable that wires everything together.

--- a/liblpmd/CMakeLists.txt
+++ b/liblpmd/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(liblpmd
+    src/simulation.cpp
+    src/plugin_loader.cpp
+)
+
+add_library(lpmd::core ALIAS liblpmd)
+
+target_include_directories(liblpmd
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(liblpmd PUBLIC cxx_std_17)
+
+if(WIN32)
+    target_compile_definitions(liblpmd PRIVATE NOMINMAX)
+endif()

--- a/liblpmd/README.md
+++ b/liblpmd/README.md
@@ -1,4 +1,13 @@
-liblpmd
-=======
+# liblpmd
 
-Libraries of lpmd (API)
+The core library that exposes simulation primitives and plugin utilities for lpmd2.
+
+## Contents
+
+- `include/lpmd/particle.hpp` – Particle definition used by the simulation.
+- `include/lpmd/force_field.hpp` – Abstract interface implemented by force-field plugins.
+- `include/lpmd/simulation.hpp` – Lightweight integrator that advances particles in time.
+- `include/lpmd/plugin_loader.hpp` – Cross-platform dynamic loader for plugins.
+- `src/` – Implementations for the headers above.
+
+The library exports the `lpmd::core` target. Downstream components simply link against it.

--- a/liblpmd/include/lpmd/force_field.hpp
+++ b/liblpmd/include/lpmd/force_field.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "lpmd/particle.hpp"
+
+namespace lpmd {
+
+class ForceField {
+public:
+    virtual ~ForceField() = default;
+    virtual void apply(std::vector<Particle>& particles, double dt) = 0;
+    virtual std::string name() const = 0;
+};
+
+using ForceFieldPtr = std::unique_ptr<ForceField>;
+using ForceFieldFactory = ForceFieldPtr (*)();
+
+inline constexpr const char* kForceFieldFactorySymbol = "create_force_field";
+
+}  // namespace lpmd

--- a/liblpmd/include/lpmd/particle.hpp
+++ b/liblpmd/include/lpmd/particle.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <array>
+
+namespace lpmd {
+
+struct Particle {
+    std::array<double, 3> position{0.0, 0.0, 0.0};
+    std::array<double, 3> velocity{0.0, 0.0, 0.0};
+    double mass{1.0};
+};
+
+}  // namespace lpmd

--- a/liblpmd/include/lpmd/plugin_loader.hpp
+++ b/liblpmd/include/lpmd/plugin_loader.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "lpmd/force_field.hpp"
+
+namespace lpmd {
+
+class PluginLoader {
+public:
+    explicit PluginLoader(std::filesystem::path library_path);
+    PluginLoader(PluginLoader&& other) noexcept;
+    PluginLoader& operator=(PluginLoader&& other) noexcept;
+    ~PluginLoader();
+
+    PluginLoader(const PluginLoader&) = delete;
+    PluginLoader& operator=(const PluginLoader&) = delete;
+
+    [[nodiscard]] ForceFieldPtr create_force_field() const;
+    [[nodiscard]] const std::filesystem::path& library_path() const noexcept { return library_path_; }
+
+private:
+    void close();
+
+    std::filesystem::path library_path_{};
+    void* handle_{nullptr};
+    ForceFieldFactory factory_{nullptr};
+};
+
+std::filesystem::path default_plugin_name();
+std::filesystem::path append_platform_suffix(const std::filesystem::path& base_name);
+
+}  // namespace lpmd

--- a/liblpmd/include/lpmd/simulation.hpp
+++ b/liblpmd/include/lpmd/simulation.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "lpmd/force_field.hpp"
+#include "lpmd/particle.hpp"
+
+namespace lpmd {
+
+class Simulation {
+public:
+    Simulation() = default;
+    Simulation(std::vector<Particle> particles, ForceFieldPtr force_field);
+
+    void set_force_field(ForceFieldPtr force_field);
+    void set_particles(std::vector<Particle> particles);
+
+    void step(double dt);
+    void run(std::size_t steps, double dt);
+
+    [[nodiscard]] const std::vector<Particle>& particles() const noexcept { return particles_; }
+    [[nodiscard]] double time() const noexcept { return time_; }
+
+private:
+    std::vector<Particle> particles_{};
+    ForceFieldPtr force_field_{};
+    double time_{0.0};
+};
+
+}  // namespace lpmd

--- a/liblpmd/src/plugin_loader.cpp
+++ b/liblpmd/src/plugin_loader.cpp
@@ -1,0 +1,119 @@
+#include "lpmd/plugin_loader.hpp"
+
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace lpmd {
+namespace {
+
+void* open_library(const std::filesystem::path& path) {
+#if defined(_WIN32)
+    HMODULE module = LoadLibraryW(path.wstring().c_str());
+    if (!module) {
+        std::ostringstream message;
+        message << "Failed to load plugin '" << path.string() << "'";
+        throw std::runtime_error(message.str());
+    }
+    return module;
+#else
+    void* handle = dlopen(path.c_str(), RTLD_NOW);
+    if (!handle) {
+        std::ostringstream message;
+        message << "Failed to load plugin '" << path.string() << "': " << dlerror();
+        throw std::runtime_error(message.str());
+    }
+    return handle;
+#endif
+}
+
+void close_library(void* handle) {
+    if (!handle) {
+        return;
+    }
+#if defined(_WIN32)
+    FreeLibrary(static_cast<HMODULE>(handle));
+#else
+    dlclose(handle);
+#endif
+}
+
+ForceFieldFactory load_factory(void* handle) {
+#if defined(_WIN32)
+    auto symbol = reinterpret_cast<ForceFieldFactory>(GetProcAddress(
+        static_cast<HMODULE>(handle), kForceFieldFactorySymbol));
+#else
+    auto symbol = reinterpret_cast<ForceFieldFactory>(dlsym(handle, kForceFieldFactorySymbol));
+#endif
+    if (!symbol) {
+        throw std::runtime_error("The loaded plugin does not expose the expected factory function");
+    }
+    return symbol;
+}
+
+}  // namespace
+
+PluginLoader::PluginLoader(std::filesystem::path library_path)
+    : library_path_(std::filesystem::absolute(std::move(library_path))) {
+    handle_ = open_library(library_path_);
+    factory_ = load_factory(handle_);
+}
+
+PluginLoader::PluginLoader(PluginLoader&& other) noexcept {
+    *this = std::move(other);
+}
+
+PluginLoader& PluginLoader::operator=(PluginLoader&& other) noexcept {
+    if (this != &other) {
+        close();
+        library_path_ = std::move(other.library_path_);
+        handle_ = other.handle_;
+        factory_ = other.factory_;
+        other.handle_ = nullptr;
+        other.factory_ = nullptr;
+    }
+    return *this;
+}
+
+PluginLoader::~PluginLoader() {
+    close();
+}
+
+ForceFieldPtr PluginLoader::create_force_field() const {
+    if (!factory_) {
+        throw std::runtime_error("Plugin factory was not loaded correctly");
+    }
+    return factory_();
+}
+
+void PluginLoader::close() {
+    if (handle_) {
+        close_library(handle_);
+        handle_ = nullptr;
+        factory_ = nullptr;
+    }
+}
+
+std::filesystem::path append_platform_suffix(const std::filesystem::path& base_name) {
+    std::filesystem::path with_extension = base_name;
+#if defined(_WIN32)
+    with_extension += ".dll";
+#elif defined(__APPLE__)
+    with_extension += ".dylib";
+#else
+    with_extension += ".so";
+#endif
+    return with_extension;
+}
+
+std::filesystem::path default_plugin_name() {
+    return append_platform_suffix("lpmd_force_constant");
+}
+
+}  // namespace lpmd

--- a/liblpmd/src/simulation.cpp
+++ b/liblpmd/src/simulation.cpp
@@ -1,0 +1,33 @@
+#include "lpmd/simulation.hpp"
+
+#include <stdexcept>
+
+namespace lpmd {
+
+Simulation::Simulation(std::vector<Particle> particles, ForceFieldPtr force_field)
+    : particles_(std::move(particles)), force_field_(std::move(force_field)) {}
+
+void Simulation::set_force_field(ForceFieldPtr force_field) {
+    force_field_ = std::move(force_field);
+}
+
+void Simulation::set_particles(std::vector<Particle> particles) {
+    particles_ = std::move(particles);
+    time_ = 0.0;
+}
+
+void Simulation::step(double dt) {
+    if (!force_field_) {
+        throw std::runtime_error("No force field configured for the simulation");
+    }
+    force_field_->apply(particles_, dt);
+    time_ += dt;
+}
+
+void Simulation::run(std::size_t steps, double dt) {
+    for (std::size_t i = 0; i < steps; ++i) {
+        step(dt);
+    }
+}
+
+}  // namespace lpmd

--- a/lpmd/CMakeLists.txt
+++ b/lpmd/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(lpmd
+    src/main.cpp
+)
+
+target_link_libraries(lpmd
+    PRIVATE
+        lpmd::core
+)
+
+target_compile_features(lpmd PUBLIC cxx_std_17)
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(lpmd PRIVATE dl)
+endif()

--- a/lpmd/README.md
+++ b/lpmd/README.md
@@ -1,4 +1,3 @@
-lpmd
-====
+# lpmd
 
-LPMD main program repository.
+Command line executable that wires the core library and plugins together. By default it looks for the `lpmd_force_constant` plugin next to the binary, but you can pass a custom plugin path as an argument.

--- a/lpmd/src/main.cpp
+++ b/lpmd/src/main.cpp
@@ -1,0 +1,62 @@
+#include <filesystem>
+#include <iostream>
+#include <vector>
+
+#include "lpmd/plugin_loader.hpp"
+#include "lpmd/simulation.hpp"
+
+namespace fs = std::filesystem;
+
+fs::path resolve_plugin_path(const char* executable_path, const char* user_path) {
+    if (user_path) {
+        return fs::absolute(user_path);
+    }
+
+    const fs::path exe_dir = fs::absolute(fs::path(executable_path).parent_path());
+    const fs::path plugin_name = lpmd::default_plugin_name();
+
+    const fs::path candidates[] = {
+        exe_dir / plugin_name,
+        exe_dir / ".." / plugin_name,
+        exe_dir / "../lib" / plugin_name,
+        fs::current_path() / plugin_name,
+    };
+
+    for (const auto& candidate : candidates) {
+        if (fs::exists(candidate)) {
+            return candidate;
+        }
+    }
+
+    return candidates[0];
+}
+
+int main(int argc, char** argv) {
+    try {
+        const char* user_path = argc > 1 ? argv[1] : nullptr;
+        fs::path plugin_path = resolve_plugin_path(argv[0], user_path);
+
+        lpmd::PluginLoader loader(plugin_path);
+        auto force_field = loader.create_force_field();
+        std::vector<lpmd::Particle> particles{
+            {{0.0, 0.0, 10.0}, {1.0, 0.0, 0.0}, 1.0},
+            {{1.0, 0.0, 15.0}, {0.0, 1.0, 0.0}, 2.0},
+        };
+
+        lpmd::Simulation simulation(std::move(particles), std::move(force_field));
+        simulation.run(10, 0.1);
+
+        std::cout << "Simulation time: " << simulation.time() << "s\n";
+        std::size_t index = 0;
+        for (const auto& particle : simulation.particles()) {
+            std::cout << "Particle " << index++ << ": position = (" << particle.position[0] << ", "
+                      << particle.position[1] << ", " << particle.position[2] << ")" << std::endl;
+        }
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << std::endl;
+        std::cerr << "Usage: " << argv[0] << " [plugin-path]" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(lpmd_force_constant SHARED
+    src/constant_force.cpp
+)
+
+target_include_directories(lpmd_force_constant
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/liblpmd/include
+)
+
+target_link_libraries(lpmd_force_constant
+    PRIVATE
+        lpmd::core
+)
+
+target_compile_features(lpmd_force_constant PUBLIC cxx_std_17)
+
+set_target_properties(lpmd_force_constant PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "lpmd_force_constant"
+)

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,4 +1,5 @@
-plugins
-=======
+# plugins
 
-Plugins of lpmd
+Shared libraries that implement `lpmd::ForceField` instances. The build currently provides a `lpmd_force_constant` plugin that applies a uniform acceleration to all particles.
+
+Additional plugins can be added by creating a new shared library that exposes the `create_force_field` factory declared in `lpmd/force_field.hpp`.

--- a/plugins/src/constant_force.cpp
+++ b/plugins/src/constant_force.cpp
@@ -1,0 +1,36 @@
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "lpmd/force_field.hpp"
+
+namespace {
+
+class ConstantForceField : public lpmd::ForceField {
+public:
+    ConstantForceField(std::array<double, 3> force) : force_(force) {}
+
+    void apply(std::vector<lpmd::Particle>& particles, double dt) override {
+        for (auto& particle : particles) {
+            std::array<double, 3> acceleration{};
+            for (std::size_t i = 0; i < 3; ++i) {
+                acceleration[i] = force_[i] / particle.mass;
+                particle.velocity[i] += acceleration[i] * dt;
+                particle.position[i] += particle.velocity[i] * dt;
+            }
+        }
+    }
+
+    std::string name() const override { return "constant-force"; }
+
+private:
+    std::array<double, 3> force_;
+};
+
+}  // namespace
+
+extern "C" lpmd::ForceFieldPtr create_force_field() {
+    return std::make_unique<ConstantForceField>(std::array<double, 3>{0.0, 0.0, -9.81});
+}


### PR DESCRIPTION
## Summary
- add a top-level CMake project that builds the liblpmd core, plugins, and the lpmd executable together
- implement the core simulation primitives, plugin loader, and a sample constant-force plugin
- provide a command line driver and refreshed documentation that explain how to build and run the project

## Testing
- cmake -S . -B build
- cmake --build build
- ./build/bin/lpmd


------
https://chatgpt.com/codex/tasks/task_e_68dd2338a3c8832f982a50989ae0487d