### PR TITLE
Expand liblpmd docs and validate simulation force fields

### DIFF
--- a/liblpmd/README.md
+++ b/liblpmd/README.md
@@ -1,13 +1,86 @@
 # liblpmd
 
-The core library that exposes simulation primitives and plugin utilities for lpmd2.
+`liblpmd` is the reusable core of the lpmd2 project. It exposes the data
+structures and abstractions required to integrate particles in time while
+allowing force-field implementations to be loaded at run time from plugins.
 
-## Contents
+## Architecture at a glance
 
-- `include/lpmd/particle.hpp` – Particle definition used by the simulation.
-- `include/lpmd/force_field.hpp` – Abstract interface implemented by force-field plugins.
-- `include/lpmd/simulation.hpp` – Lightweight integrator that advances particles in time.
-- `include/lpmd/plugin_loader.hpp` – Cross-platform dynamic loader for plugins.
-- `src/` – Implementations for the headers above.
+The library is intentionally small and layered so downstream executables can
+orchestrate simulations without duplicating logic:
 
-The library exports the `lpmd::core` target. Downstream components simply link against it.
+| Component | Responsibility |
+|-----------|----------------|
+| [`Particle`](include/lpmd/particle.hpp) | Immutable description of a particle's instantaneous state (position, velocity and mass). |
+| [`ForceField`](include/lpmd/force_field.hpp) | Polymorphic interface implemented by plugins. The `apply()` method mutates a particle array in place, advancing the system by a time step. |
+| [`Simulation`](include/lpmd/simulation.hpp) | Small driver that owns the particle container, keeps track of simulation time and repeatedly applies a force field. |
+| [`PluginLoader`](include/lpmd/plugin_loader.hpp) | Cross-platform wrapper for dynamically loading a shared library and retrieving the exported factory symbol. |
+
+The implementation files under [`src/`](src) provide the runtime behaviour for
+the headers above. The public CMake target exported by the directory is
+`lpmd::core`, an alias for the actual `liblpmd` static/shared library.
+
+## Simulation lifecycle
+
+1. **Load a force field** – Use `PluginLoader` with either an explicit path or
+   `default_plugin_name()`/`append_platform_suffix()` to resolve a platform
+   specific library name. The loader validates that the expected
+   `create_force_field` factory is present before exposing it to callers.
+2. **Instantiate the simulation** – Provide an initial particle array and a
+   `ForceFieldPtr` to the `Simulation` constructor, or create the simulation
+   first and call `set_force_field()` once the plugin is available. Both paths
+   enforce that the force field pointer is non-null, maintaining internal
+   invariants.
+3. **Integrate** – Call `step(dt)` to advance the system once or `run(steps,
+   dt)` for repeated integration. The simulation updates its internal clock via
+   `time()`, and exposes the evolving particle container through `particles()`.
+
+Each integration step delegates to the active force field implementation. This
+separation keeps `Simulation` agnostic to the specific physics while providing
+consistent bookkeeping of time and particle state.
+
+## Error handling and invariants
+
+* `Simulation::set_force_field()` now rejects null pointers, throwing
+  `std::invalid_argument`. This prevents accidental usage of an uninitialised
+  simulation that would otherwise fail later during integration.
+* `Simulation::step()` throws `std::runtime_error` when no force field is
+  configured. Client code should catch this error to surface meaningful messages
+  to end users.
+* `PluginLoader` normalises the library path to an absolute path and releases
+  native handles automatically when the loader is destroyed or moved from.
+
+None of the core classes are thread-safe by themselves. Callers that manipulate
+shared simulations or plugin loaders must introduce external synchronisation.
+
+## Building only `liblpmd`
+
+`liblpmd` is integrated into the repository's top-level CMake project. The
+following commands configure a build tree and compile only the core library:
+
+```bash
+cmake -S . -B build/liblpmd -DCMAKE_BUILD_TYPE=Release
+cmake --build build/liblpmd --target liblpmd
+```
+
+The first command configures the entire project, but the second command limits
+the actual compilation step to the `liblpmd` target. Replace `Release` with
+`Debug` (or any other CMake build type) as needed. To install just the library
+and its headers you can run `cmake --install build/liblpmd --component liblpmd`
+once a corresponding install rule is added to the project.
+
+## Opportunities for further improvement
+
+While reviewing the codebase a few possible enhancements emerged:
+
+* **Time-step validation** – Guarding against non-positive `dt` values in
+  `Simulation::step()` would catch configuration errors earlier.
+* **Plugin diagnostics** – Extending the Windows loader branch to surface the
+  message associated with `GetLastError()` would improve debugging failed
+  loads.
+* **Optional logging hooks** – Thread-safe logging callbacks inside
+  `PluginLoader` and `Simulation` would simplify integrating the library into
+  larger applications that require detailed audit trails.
+
+These ideas are not required for correct behaviour today but could make the
+library even more robust and user friendly in the future.

--- a/liblpmd/include/lpmd/plugin_loader.hpp
+++ b/liblpmd/include/lpmd/plugin_loader.hpp
@@ -8,6 +8,7 @@
 
 namespace lpmd {
 
+/// RAII wrapper around a dynamically loaded force-field plugin.
 class PluginLoader {
 public:
     explicit PluginLoader(std::filesystem::path library_path);
@@ -18,18 +19,21 @@ public:
     PluginLoader(const PluginLoader&) = delete;
     PluginLoader& operator=(const PluginLoader&) = delete;
 
+    /// Instantiate a new force field using the plugin's exported factory.
     [[nodiscard]] ForceFieldPtr create_force_field() const;
     [[nodiscard]] const std::filesystem::path& library_path() const noexcept { return library_path_; }
 
 private:
-    void close();
+    void close() noexcept;
 
     std::filesystem::path library_path_{};
     void* handle_{nullptr};
     ForceFieldFactory factory_{nullptr};
 };
 
+/// Return the default plugin shared library name for the current platform.
 std::filesystem::path default_plugin_name();
+/// Append the operating system specific extension to a plugin base name.
 std::filesystem::path append_platform_suffix(const std::filesystem::path& base_name);
 
 }  // namespace lpmd

--- a/liblpmd/include/lpmd/simulation.hpp
+++ b/liblpmd/include/lpmd/simulation.hpp
@@ -8,15 +8,32 @@
 
 namespace lpmd {
 
+/// Lightweight driver that advances a collection of particles using a force
+/// field provided by plugins.
 class Simulation {
 public:
     Simulation() = default;
+    /// Construct a simulation with an initial particle set and a force field.
+    ///
+    /// The force field must be non-null; use the default constructor followed
+    /// by set_force_field() when deferring plugin loading.
     Simulation(std::vector<Particle> particles, ForceFieldPtr force_field);
 
+    /// Install the force field used by subsequent integration steps.
+    ///
+    /// Passing a null pointer is rejected to keep the object in a valid
+    /// state. Clients that need to unload a force field should create a fresh
+    /// Simulation instance instead.
     void set_force_field(ForceFieldPtr force_field);
+
+    /// Replace the particle container. The integration time is reset because
+    /// the new state represents the beginning of a trajectory.
     void set_particles(std::vector<Particle> particles);
 
+    /// Advance the system by a single time step.
     void step(double dt);
+
+    /// Execute multiple time steps back-to-back.
     void run(std::size_t steps, double dt);
 
     [[nodiscard]] const std::vector<Particle>& particles() const noexcept { return particles_; }

--- a/liblpmd/src/plugin_loader.cpp
+++ b/liblpmd/src/plugin_loader.cpp
@@ -114,7 +114,7 @@ ForceFieldPtr PluginLoader::create_force_field() const {
     return factory_();
 }
 
-void PluginLoader::close() {
+void PluginLoader::close() noexcept {
     if (handle_) {
         close_library(handle_);
         handle_ = nullptr;

--- a/liblpmd/src/simulation.cpp
+++ b/liblpmd/src/simulation.cpp
@@ -5,9 +5,14 @@
 namespace lpmd {
 
 Simulation::Simulation(std::vector<Particle> particles, ForceFieldPtr force_field)
-    : particles_(std::move(particles)), force_field_(std::move(force_field)) {}
+    : particles_(std::move(particles)) {
+    set_force_field(std::move(force_field));
+}
 
 void Simulation::set_force_field(ForceFieldPtr force_field) {
+    if (!force_field) {
+        throw std::invalid_argument("Simulation requires a non-null force field");
+    }
     force_field_ = std::move(force_field);
 }
 


### PR DESCRIPTION
## Summary
- expand the liblpmd README with an architecture overview, lifecycle walkthrough, and build instructions
- document the Simulation and PluginLoader interfaces in the public headers
- enforce non-null force fields when configuring simulations and mark plugin cleanup noexcept

## Testing
- cmake -S . -B build
- cmake --build build --target liblpmd

------
https://chatgpt.com/codex/tasks/task_e_68dd4461e6cc832fba10d980bf632633