### PR TITLE
Fix warnings in command parsing and simulation labels

### DIFF
--- a/liblpmd/runtime/cmdline.cc
+++ b/liblpmd/runtime/cmdline.cc
@@ -90,7 +90,7 @@ void CommandArguments::Parse(int argc, const char ** argv)
    }
    if (optfound == false) throw SyntaxError("Unknown command line option, -"+optname);
    optargs = StringSplit(curropt.args);
-   (*this)[curropt.longname] == "true";
+   (*this)[curropt.longname] = "true";
   }
   else
   {

--- a/liblpmd/simulation/simulationbuilder.cc
+++ b/liblpmd/simulation/simulationbuilder.cc
@@ -110,7 +110,7 @@ template <typename AtomContainer=lpmd::ParticleSet, typename CellType=lpmd::Cell
   SetTag(*this, Tag("pressure"), (pressfactor/v)*((2.0/3.0)*kinenerg+(1.0/3.0)*Virial()));
 
   char component_letter[3] = {'x', 'y', 'z'};
-  char label_buf[4] = {'s', NULL, NULL, NULL};
+  char label_buf[4] = {'s', '\0', '\0', '\0'};
   for (int p=0;p<3;++p)
    for (int q=0;q<3;++q)
    {


### PR DESCRIPTION
## Summary
- correct the short option parsing logic to mark options as present
- initialize the stress label buffer with null terminators instead of NULL pointers

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68dda1799354832f96de2bdace411eca