### PR TITLE
Fix random filter selection to include every atom

### DIFF
--- a/plugins/random.cc
+++ b/plugins/random.cc
@@ -28,7 +28,7 @@ class RandomSelector: public Selector<BasicParticleSet>
     while(random.Size()<tochange)
     {
       int rnd = int(drand48()*ps.Size());
-      if (rnd!=0) random.AppendUnique(rnd);
+      random.AppendUnique(rnd);
     }
     std::cerr << "-> random Size = " << random.Size() << '\n';
     for(int i=0;i<random.Size();++i)
@@ -49,7 +49,7 @@ class RandomSelector: public Selector<BasicParticleSet>
     while(random.Size()<tochange)
     {
      int rnd = int(drand48()*ps.Size());
-     if (rnd!=0) random.AppendUnique(rnd);
+     random.AppendUnique(rnd);
     }
     for(int i=0;i<random.Size();++i)
     {


### PR DESCRIPTION
## Summary
- allow the random filter plugin to select every atom by removing the guard that skipped index 0
- prevent hangs when requesting 100% selection or deletion due to the first atom being excluded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddce073400832fa117de1b6b1c5dbf