### PR TITLE
Add dependency installation helper before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ A modernized CMake build that combines the core `liblpmd` library, runtime plugi
 
 ## Building
 
+Before configuring the project make sure the required system packages are
+available. The repository ships with a small helper script that installs the
+compiler toolchain, CMake, and the GLUT development headers on the most common
+Linux distributions:
+
+```bash
+./scripts/install_requirements.sh
+```
+
+Once the dependencies are in place you can configure and build the project:
+
 ```bash
 cmake -S . -B build
 cmake --build build

--- a/docs/COMPILATION.md
+++ b/docs/COMPILATION.md
@@ -5,11 +5,17 @@ compiles successfully from a clean checkout.
 
 ## Steps
 
-1. Configure the project and generate the build system files:
+1. Install the system requirements (compiler toolchain, CMake, GLUT headers).
+   The provided helper script covers the most common Linux distributions:
+   ```bash
+   ./scripts/install_requirements.sh
+   ```
+
+2. Configure the project and generate the build system files:
    ```bash
    cmake -S . -B build
    ```
-2. Build all targets:
+3. Build all targets:
    ```bash
    cmake --build build
    ```

--- a/scripts/install_requirements.sh
+++ b/scripts/install_requirements.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  ${SUDO} apt-get update
+  ${SUDO} apt-get install -y build-essential cmake freeglut3-dev
+elif command -v dnf >/dev/null 2>&1; then
+  ${SUDO} dnf install -y gcc gcc-c++ make cmake freeglut-devel
+elif command -v pacman >/dev/null 2>&1; then
+  ${SUDO} pacman -Sy --noconfirm base-devel cmake freeglut
+else
+  echo "Unsupported package manager. Please install build tools, CMake, and GLUT development headers manually." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a helper script to install the compiler, CMake, and GLUT headers on common Linux distros
- document running the requirements installer before invoking the build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddcf147eb4832faba322f3659eb914