### PR TITLE
Fix compilation warnings in plugins

### DIFF
--- a/plugins/display.cc
+++ b/plugins/display.cc
@@ -951,7 +951,12 @@ void DrawStatistics(void)
    glLoadIdentity();
    glOrtho(0,sseg->width1,-sseg->height1,0,-10,10);
    glMatrixMode(GL_MODELVIEW);
-   GLfloat pos[] = {1.5*sseg->width1, -sseg->height1/2, 10, 0};
+   const GLfloat pos[] = {
+    static_cast<GLfloat>(1.5 * sseg->width1),
+    static_cast<GLfloat>(-0.5 * static_cast<double>(sseg->height1)),
+    10.0f,
+    0.0f
+   };
    glLightfv(GL_LIGHT0,GL_POSITION,pos);
    
    glPushMatrix();

--- a/plugins/lpmd.cc
+++ b/plugins/lpmd.cc
@@ -125,7 +125,7 @@ void LPMDFormat::ShowHelp() const
 
 void LPMDFormat::ReadHeader(std::istream & is) const
 {
- char first[2] = { NULL, NULL };
+ char first[2] = { '\0', '\0' };
  is.read(first, 1);
  if (first[0] == 'Z')
  {


### PR DESCRIPTION
## Summary
- avoid implicit narrowing in the OpenGL light position array used by the display plugin
- replace NULL initialisation in the lpmd plugin header parsing with explicit null characters

## Testing
- cmake -S . -B build
- cmake --build build *(fails: missing system OpenGL headers in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd0b94474832f84cc4d659ef80b9b