### PR TITLE
Add CMake support for lpmd executables and optional OpenGL plugins

### DIFF
--- a/lpmd/CMakeLists.txt
+++ b/lpmd/CMakeLists.txt
@@ -1,0 +1,97 @@
+set(LPMD_APP_VERSION "${PROJECT_VERSION}")
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/config.h
+    @ONLY
+)
+
+set(LPMD_UTILITY_SOURCES
+    application.cc
+    autotest.cc
+    controlparser.cc
+    help.cc
+    palmtree.cc
+    quickmode.cc
+    refsimulation.cc
+    replayintegrator.cc
+)
+
+add_library(lpmd_app_support STATIC ${LPMD_UTILITY_SOURCES})
+add_library(lpmd::app_support ALIAS lpmd_app_support)
+
+target_link_libraries(lpmd_app_support
+    PUBLIC
+        lpmd::core
+)
+
+target_include_directories(lpmd_app_support
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+target_compile_features(lpmd_app_support PUBLIC cxx_std_17)
+
+set(LPMD_APPS
+    lpmd
+    lpmd-analyzer
+    lpmd-converter
+    lpmd-visualizer
+)
+
+foreach(app_name ${LPMD_APPS})
+    if(app_name STREQUAL "lpmd")
+        set(app_source lpmd.cc)
+    elseif(app_name STREQUAL "lpmd-analyzer")
+        set(app_source analyzer.cc)
+    elseif(app_name STREQUAL "lpmd-converter")
+        set(app_source converter.cc)
+    elseif(app_name STREQUAL "lpmd-visualizer")
+        set(app_source visualizer.cc)
+    else()
+        message(FATAL_ERROR "Unknown application ${app_name}")
+    endif()
+
+    string(REPLACE "-" "_" target_name "${app_name}")
+    if(app_name STREQUAL "lpmd")
+        set(target_name "lpmd")
+    endif()
+
+    add_executable(${target_name} ${app_source})
+    target_link_libraries(${target_name} PRIVATE lpmd::app_support)
+
+    if(NOT app_name STREQUAL "lpmd")
+        set_target_properties(${target_name} PROPERTIES OUTPUT_NAME "${app_name}")
+    endif()
+endforeach()
+
+set(LPMD_PYTHON_BIN_SCRIPTS
+    lpmd-plotter.py
+)
+
+foreach(script ${LPMD_PYTHON_BIN_SCRIPTS})
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/${script}
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${script}
+        COPYONLY
+    )
+endforeach()
+
+set(LPMD_PYTHON_PACKAGE_SCRIPTS
+    lpplotter/__init__.py
+    lpplotter/makeframes.py
+    lpplotter/parselpmd2.py
+    lpplotter/povscene.py
+)
+
+if(LPMD_PYTHON_PACKAGE_SCRIPTS)
+    file(MAKE_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lpplotter)
+    foreach(script ${LPMD_PYTHON_PACKAGE_SCRIPTS})
+        get_filename_component(script_name "${script}" NAME)
+        configure_file(
+            ${CMAKE_CURRENT_SOURCE_DIR}/${script}
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lpplotter/${script_name}
+            COPYONLY
+        )
+    endforeach()
+endif()

--- a/lpmd/config.h.in
+++ b/lpmd/config.h.in
@@ -7,7 +7,7 @@
 #ifndef __LPMDUTILS_CONFIG_H__
 #define __LPMDUTILS_CONFIG_H__
 
-#define VERSION "$(version)"
+#define VERSION "@LPMD_APP_VERSION@"
 
 #endif
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -21,8 +21,16 @@ list(SORT PLUGIN_SOURCES)
 # the structure below makes it straightforward to extend if additional
 # third‑party dependencies are introduced later on.
 set(ZLIB_PLUGINS lammps lpmd)
+set(OPENGL_PLUGINS display lpvisual)
 
 find_package(ZLIB REQUIRED)
+find_package(OpenGL)
+find_package(GLUT)
+
+set(HAVE_OPENGL OFF)
+if(OpenGL_FOUND AND GLUT_FOUND)
+    set(HAVE_OPENGL ON)
+endif()
 
 foreach(plugin_src ${PLUGIN_SOURCES})
     get_filename_component(plugin_name "${plugin_src}" NAME_WE)
@@ -30,6 +38,11 @@ foreach(plugin_src ${PLUGIN_SOURCES})
     # targets) while preserving the output file name expected by LPMD at
     # runtime.
     string(REPLACE "-" "_" plugin_target "plugin_${plugin_name}")
+
+    if(plugin_name IN_LIST OPENGL_PLUGINS AND NOT HAVE_OPENGL)
+        message(WARNING "Skipping '${plugin_name}' plugin: OpenGL/GLUT headers not found")
+        continue()
+    endif()
 
     add_library(${plugin_target} MODULE "${plugin_src}")
     target_link_libraries(${plugin_target} PRIVATE lpmd::core)
@@ -45,5 +58,9 @@ foreach(plugin_src ${PLUGIN_SOURCES})
 
     if(plugin_name IN_LIST ZLIB_PLUGINS)
         target_link_libraries(${plugin_target} PRIVATE ZLIB::ZLIB)
+    endif()
+
+    if(plugin_name IN_LIST OPENGL_PLUGINS)
+        target_link_libraries(${plugin_target} PRIVATE OpenGL::GL OpenGL::GLU GLUT::GLUT)
     endif()
 endforeach()


### PR DESCRIPTION
## Summary
- add a dedicated CMakeLists.txt to build the lpmd command line tools and copy the associated python helpers
- expose the project version to the lpmd apps through the generated config header
- make the display-related plugins optional when OpenGL/GLUT headers are not available

## Testing
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68de7258d6ac832f8fb5b6161d02bff2