### PR TITLE
Fix build regressions in module and plugins

### DIFF
--- a/liblpmd/lpmd/combinedpotential.h
+++ b/liblpmd/lpmd/combinedpotential.h
@@ -8,6 +8,7 @@
 #define __LPMD_COMBINED_POTENTIAL_H__
 
 #include <lpmd/array.h>
+#include <lpmd/configuration.h>
 #include <lpmd/error.h>
 #include <lpmd/potential.h>
 

--- a/liblpmd/lpmd/module.h
+++ b/liblpmd/lpmd/module.h
@@ -1,24 +1,26 @@
-//
-//
-//
+#ifndef LPMD_MODULE_H
+#define LPMD_MODULE_H
 
-/**
- *  \file module.h
-#include <list>
+#include <iosfwd>
+#include <string>
+
+#include <lpmd/paramlist.h>
+
 namespace lpmd {
-class PluginManager; // forward declaration
+
+class PluginManager;
+
 class Module : public ParamList {
 public:
-  /// Constructor que recibe un nombre para el mdulo.
   Module(std::string modulename, bool strictkw = true);
-  /// Constructor de copia
   Module(const Module& mod);
-  /// Destructor.
   virtual ~Module();
+
+  Module& operator=(const Module& mod);
 
   void ProcessArguments(std::string line);
   std::string GetNextWord();
-  std::string GetNextWord(char);
+  std::string GetNextWord(char delimiter);
 
   virtual void ShowHelp() const;
 
@@ -26,50 +28,27 @@ public:
 
   PluginManager& GetManager() const;
 
-  //
   void AssignParameter(const std::string& key, std::string value);
   void DefineKeyword(const std::string kw, const std::string defvalue);
   void DefineKeyword(const std::string kw);
 
-  // Flujo de depuracion
   void SetDebugFile(const std::string debugfile);
   void SetDebugStream(std::ostream& ostr);
   std::ostream& DebugStream() const;
 
-  // Operador de asignacion
-  Module& operator=(const Module& mod);
-
-  // Virtuales con implementacion por omisin
-  virtual void
-  Show() const; // This defaults to Show(std::cout) but it depends on the implementation of liblpmd
+  virtual void Show() const;
   virtual void Show(std::ostream& os) const;
   virtual std::string Provides() const;
   virtual double GetProperty(const std::string& name);
   virtual void SetParameter(std::string name);
   virtual std::string Keywords() const;
 
-  // FIXME : Cambiar este metodo por un parametro extra en el constructor
   void SetManager(PluginManager& pm);
 
 private:
   class ModuleImpl* impl;
-} // namespace lpmd
-
-   virtual void Show(std::ostream & os) const; 
-   virtual std::string Provides() const;
-   virtual double GetProperty(const std::string & name);
-   virtual void SetParameter(std::string name);
-   virtual std::string Keywords() const;
-
-   // FIXME : Cambiar este metodo por un parametro extra en el constructor
-   void SetManager(PluginManager & pm);
-
- private:
-   class ModuleImpl * impl;
 };
 
-} // lpmd
+} // namespace lpmd
 
-#endif
-
-
+#endif // LPMD_MODULE_H

--- a/plugins/cna.cc
+++ b/plugins/cna.cc
@@ -9,6 +9,7 @@
 #include <lpmd/matrix.h>
 #include <lpmd/util.h>
 
+#include <list>
 #include <map>
 #include <sstream>
 

--- a/plugins/moleculecm.cc
+++ b/plugins/moleculecm.cc
@@ -7,6 +7,8 @@
 #include <lpmd/simulation.h>
 
 #include <iostream>
+#include <list>
+#include <map>
 
 using namespace lpmd;
 


### PR DESCRIPTION
## Summary
- restore the Module class declaration and include guard that were lost from lpmd/lpmd/module.h
- include lpmd/configuration.h so combinedpotential.h can access the configuration helpers it uses inline
- add the missing <list> includes for the CNA and moleculecm plugins that depend on std::list

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68dfd49a398c832f9b7f5996042adc68