### PR TITLE
Fix formatting of API umbrella header

### DIFF
--- a/liblpmd/lpmd/api.h
+++ b/liblpmd/lpmd/api.h
@@ -13,71 +13,45 @@
 
 /**
  *  \mainpage LPMD: Las Palmeras Molecular Dynamics
-#include <lpmd/error.h>
-#include <lpmd/physunits.h>
-#include <lpmd/timer.h>
-#include <lpmd/util.h>
-// Plugin loading
-
-// Math
-#include <lpmd/vector.h>
-// Simulation data
-#include <lpmd/atompair.h>
-#include <lpmd/pairpotential.h>
-#include <lpmd/potential.h>
-#include <lpmd/potentialarray.h>
-// Molecular dynamics
-
-#include <lpmd/temporalproperty.h>
-
-#include <lpmd/plugin.h>
-#include <lpmd/pluginmanager.h>
-
-// Math 
-
-#include <lpmd/vector.h>
-#include <lpmd/matrix.h>
-#include <lpmd/scalartable.h>
-#include <lpmd/scalarvalue.h>
-#include <lpmd/vectorvalue.h>
-
-// Simulation data 
+ *
+ *  This header aggregates the most commonly used headers in the LPMD
+ *  codebase so that applications can include the complete public API with a
+ *  single directive.
+ */
 
 #include <lpmd/atom.h>
-#include <lpmd/cell.h>
-#include <lpmd/particles.h>
 #include <lpmd/atompair.h>
-#include <lpmd/simulationcell.h>
-
-// Potentials
-
-#include <lpmd/potential.h>
-#include <lpmd/potentialarray.h>
-#include <lpmd/coulomb.h>
-#include <lpmd/pairpotential.h>
-#include <lpmd/metalpotential.h>
-
-// Integrators
-
-#include <lpmd/integrator.h>
-#include <lpmd/onestepintegrator.h>
-#include <lpmd/twostepintegrator.h>
-
-// Molecular dynamics 
-
-#include <lpmd/simulation.h>
-
-// Other plugin types (besides Potential and Integrator)
-
+#include <lpmd/cell.h>
 #include <lpmd/cellformat.h>
 #include <lpmd/cellgenerator.h>
 #include <lpmd/cellmanager.h>
 #include <lpmd/cellreader.h>
 #include <lpmd/cellwriter.h>
+#include <lpmd/coulomb.h>
+#include <lpmd/error.h>
 #include <lpmd/instantproperty.h>
-#include <lpmd/temporalproperty.h>
+#include <lpmd/integrator.h>
+#include <lpmd/matrix.h>
+#include <lpmd/metalpotential.h>
+#include <lpmd/onestepintegrator.h>
+#include <lpmd/pairpotential.h>
+#include <lpmd/particles.h>
+#include <lpmd/physunits.h>
+#include <lpmd/plugin.h>
+#include <lpmd/pluginmanager.h>
+#include <lpmd/potential.h>
+#include <lpmd/potentialarray.h>
+#include <lpmd/scalartable.h>
+#include <lpmd/scalarvalue.h>
+#include <lpmd/simulation.h>
+#include <lpmd/simulationcell.h>
 #include <lpmd/systemmodifier.h>
+#include <lpmd/temporalproperty.h>
+#include <lpmd/timer.h>
+#include <lpmd/twostepintegrator.h>
+#include <lpmd/util.h>
+#include <lpmd/vector.h>
+#include <lpmd/vectorvalue.h>
 #include <lpmd/visualizer.h>
 
 #endif
-


### PR DESCRIPTION
## Summary
- close the doxygen mainpage comment in the API umbrella header and document its purpose
- reorganize and deduplicate the lpmd API includes so the file formats cleanly under clang-format

## Testing
- clang-format -n --Werror liblpmd/lpmd/api.h

------
https://chatgpt.com/codex/tasks/task_e_68dfd9240af0832f9af8281bb407e4a4