### PR TITLE
Fix atom copy semantics, reduce warnings, and optimize Temperature calculation

### DIFF
--- a/liblpmd/lpmd/atom.h
+++ b/liblpmd/lpmd/atom.h
@@ -24,6 +24,8 @@ public:
     iv[0] = at.Position();
     iv[1] = at.Velocity();
     iv[2] = at.Acceleration();
+    Mass() = at.Mass();
+    Charge() = at.Charge();
     // const BasicAtom & basic_at = at;
     // const BasicAtom & my_basicat = (*this);
     // if (ColorHandler::HaveColor(basic_at)) ColorHandler::ColorOfAtom(my_basicat) =
@@ -34,10 +36,17 @@ public:
     iv[0] = at.Position();
     iv[1] = at.Velocity();
     iv[2] = at.Acceleration();
+    Mass() = at.Mass();
+    Charge() = at.Charge();
     // const BasicAtom & basic_at = at;
     // const BasicAtom & my_basicat = (*this);
     // if (ColorHandler::HaveColor(basic_at)) ColorHandler::ColorOfAtom(my_basicat) =
     // ColorHandler::ColorOfAtom(basic_at);
+  }
+
+  Atom& operator=(const Atom& at) {
+    BasicAtom::operator=(at);
+    return *this;
   }
 
   Atom(const std::string a) : BasicAtom(ElemNum(a), &iv[0], &iv[1], &iv[2]) {}

--- a/liblpmd/lpmd/basicatom.h
+++ b/liblpmd/lpmd/basicatom.h
@@ -57,7 +57,8 @@ public:
   inline BasicAtom& operator=(const BasicAtom& at) {
     if (&at != this) {
       z = at.Z();
-      mass = ElemMass[z];
+      mass = at.Mass();
+      charge = at.Charge();
       Position() = at.Position();
       Velocity() = at.Velocity();
       Acceleration() = at.Acceleration();

--- a/liblpmd/lpmd/color.h
+++ b/liblpmd/lpmd/color.h
@@ -15,6 +15,7 @@ public:
   Color(double red, double green, double blue) : Vector(red, green, blue) {}
   Color(const Vector& rgb) : Vector(rgb) {}
   Color(const Color& color) : Vector(color) {}
+  Color& operator=(const Color& color) = default;
 
   inline double& Red() { return (*this)[0]; }
   inline double& Green() { return (*this)[1]; }

--- a/liblpmd/lpmd/properties.h
+++ b/liblpmd/lpmd/properties.h
@@ -37,19 +37,24 @@ template <typename T> double KineticEnergy(const T& atomcont, bool tag = false) 
 }
 
 template <typename T> double Temperature(const T& atomcont, const bool tag = false) {
-  if (atomcont.Size() == 0)
+  const long int atom_count = atomcont.Size();
+  if (atom_count == 0)
     return 0.0; //
-  int size = 0, tmp = 0;
-  if (tag == false)
-    size = atomcont.Size();
-  else {
-    for (long int i = 0; i < atomcont.Size(); ++i) {
-      if (atomcont.Have(atomcont[i], Tag("fixedvel")) ||
-          atomcont.Have(atomcont[i], Tag("fixedpos")))
-        ++tmp;
+
+  double kinetic_energy = 0.0;
+  long int fixed_count = 0;
+  for (long int i = 0; i < atom_count; ++i) {
+    if (tag &&
+        (atomcont.Have(atomcont[i], Tag("fixedvel")) ||
+         atomcont.Have(atomcont[i], Tag("fixedpos")))) {
+      ++fixed_count;
+      continue;
     }
+    kinetic_energy += 0.5 * atomcont[i].Mass() * atomcont[i].Velocity().SquareModule();
   }
-  return (2.0 / 3.0) * KineticEnergy(atomcont, tag) / (KBOLTZMANN * double(atomcont.Size() - tmp));
+
+  return (2.0 / 3.0) * (kinetic_energy * KIN2EV) /
+         (KBOLTZMANN * double(atom_count - fixed_count));
 }
 
 template <typename T, typename V> double Density(const T& atomcont, const V& cell) {

--- a/liblpmd/lpunit/macros.h
+++ b/liblpmd/lpunit/macros.h
@@ -9,7 +9,7 @@
 
 #include <lpunit/test.h>
 
-#define LPUNIT_EPICFAIL "\e[31mFAILED\e[0m\n      "
+#define LPUNIT_EPICFAIL "\033[31mFAILED\033[0m\n      "
 
 #define LPUNIT_ASSERT(a, s_a)                                                                      \
   if (!a) {                                                                                        \

--- a/liblpmd/lpunit/testsuite.cc
+++ b/liblpmd/lpunit/testsuite.cc
@@ -45,7 +45,7 @@ int TestSuite::PerformAllTests() {
     std::cout << '\n' << impl->description << " (" << n << " tests) : " << '\n';
   int cfailed = 0;
   if (n == 0) {
-    printf("*** \e[31mNo tests defined\e[0m, this counts as a failure ***\n");
+    printf("*** \033[31mNo tests defined\033[0m, this counts as a failure ***\n");
     return 1;
   }
   for (unsigned long int q = 0; q < n; ++q) {
@@ -65,7 +65,7 @@ int TestSuite::PerformAllTests() {
     if (impl->tdfunc != NULL)
       (*(impl->tdfunc))(); // calls the teardown function for the suite
     if (r == true)
-      printf("\e[32mOK\e[0m\n");
+      printf("\033[32mOK\033[0m\n");
     else {
       if (errormsg != "")
         std::cout << errormsg << '\n';
@@ -74,11 +74,11 @@ int TestSuite::PerformAllTests() {
   }
   std::cout << "\n-> " << impl->description << ": ";
   if (cfailed > 0) {
-    printf("*** %d of %lu tests (%.3f %%) \e[31mFAILED\e[0m ***\n", cfailed, n,
+    printf("*** %d of %lu tests (%.3f %%) \033[31mFAILED\033[0m ***\n", cfailed, n,
            100.0 * float(cfailed) / n);
     return 1; // some test(s) failed
   } else {
-    printf("!!! All %lu tests \e[32mPASSED\e[0m !!!\n", n);
+    printf("!!! All %lu tests \033[32mPASSED\033[0m !!!\n", n);
     return 0; // all tests OK!
   }
 }

--- a/liblpmd/simulation/pairpotential.cc
+++ b/liblpmd/simulation/pairpotential.cc
@@ -73,7 +73,6 @@ void PairPotential::UpdateForces(Configuration& conf) {
       }
     }
   }
-#pragma omp barrier
   double& config_virial = conf.Virial();
   energycache += etmp;
   config_virial += tmpvir;

--- a/liblpmd/support/util.cc
+++ b/liblpmd/support/util.cc
@@ -11,7 +11,9 @@
 
 #include <lpmd/util.h>
 
+#ifdef _MSC_VER
 #pragma warning(disable : 2259)
+#endif
 
 using namespace lpmd;
 

--- a/liblpmd/tests/atomtest.unit
+++ b/liblpmd/tests/atomtest.unit
@@ -77,6 +77,8 @@ using namespace lpmd;
 {
  Vector pos(2.0, 3.0, 4.0), vel(0.5, 0.2, 3.4), acc(50.0, 70.0, 35.0);
  Atom * at = new Atom("H", pos, vel, acc);
+ at->Mass() = 1.0;
+ at->Charge() = -1.0;
  Atom at2(*at);
  delete at;
  
@@ -85,6 +87,8 @@ using namespace lpmd;
  @approx (at2.Position()-pos).Module(), 0.0, 1.0E-10
  @approx (at2.Velocity()-vel).Module(), 0.0, 1.0E-10
  @approx (at2.Acceleration()-acc).Module(), 0.0, 1.0E-10
+ @approx at2.Mass(), 1.0, 1.0E-10
+ @approx at2.Charge(), -1.0, 1.0E-10
 }
 @end
 
@@ -92,6 +96,8 @@ using namespace lpmd;
 {
  Vector pos(2.0, 3.0, 4.0), vel(0.5, 0.2, 3.4), acc(50.0, 70.0, 35.0);
  Atom * at = new Atom("H", pos, vel, acc);
+ at->Mass() = 1.0;
+ at->Charge() = -1.0;
  Atom at2("Zr");
  @equal at2.Symbol(), "Zr" 
  at2 = *at;
@@ -102,6 +108,8 @@ using namespace lpmd;
  @approx (at2.Position()-pos).Module(), 0.0, 1.0E-10
  @approx (at2.Velocity()-vel).Module(), 0.0, 1.0E-10
  @approx (at2.Acceleration()-acc).Module(), 0.0, 1.0E-10
+ @approx at2.Mass(), 1.0, 1.0E-10
+ @approx at2.Charge(), -1.0, 1.0E-10
 }
 @end
 


### PR DESCRIPTION
### Motivation
- Preserve user-modified per-atom state (mass and charge) across copy/assignment operations to avoid silent data loss. 
- Reduce noisy compiler warnings and use standard ANSI escape sequences for test output. 
- Improve performance of `Temperature()` by avoiding a second pass over atoms while keeping results identical. 

### Description
- Ensure `Atom` copy constructor and `BasicAtom::operator=` preserve `Mass()` and `Charge()` and add `Atom::operator=` forwarding to `BasicAtom::operator=`; changes in `liblpmd/lpmd/atom.h` and `liblpmd/lpmd/basicatom.h`.
- Replace non-portable `\e` escape sequences with `\033` in test output and update `LPUNIT_EPICFAIL` formatting; changes in `liblpmd/lpunit/macros.h` and `liblpmd/lpunit/testsuite.cc`.
- Compute kinetic energy and count fixed atoms in a single loop inside `Temperature()` to avoid a second `KineticEnergy()` pass while preserving inclusion/exclusion semantics; change in `liblpmd/lpmd/properties.h`.
- Add explicit default assignment for `Color` and guard MSVC pragmas, and remove an unnecessary OpenMP barrier that could warn or stall; changes in `liblpmd/lpmd/color.h`, `liblpmd/support/util.cc`, and `liblpmd/simulation/pairpotential.cc`.
- Add regression checks to `liblpmd/tests/atomtest.unit` verifying that copy/assignment preserve mass and charge.

### Testing
- Built and ran unit tests with CMake: `cmake --build build -j2 && ctest --test-dir build --output-on-failure`, all tests passed (`19/19` passed). (Succeeded)
- Ran a pedantic build to expose warnings and verify changes, then re-built core; no new errors were introduced (build completed). (Succeeded)
- Ran Rust tests for the companion crate: `cargo test --manifest-path liblpmd/rust/Cargo.toml`, all Rust unit tests passed. (Succeeded)
- Ran `git diff --check` to ensure no whitespace/errors in diffs. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07a6cd6a948320bfb7926a2e975ec8)