### PR TITLE
Add broader unit test coverage (Matrix, ParamList, Elements, Rust histogram)

### DIFF
--- a/liblpmd/rust/src/lib.rs
+++ b/liblpmd/rust/src/lib.rs
@@ -106,4 +106,90 @@ mod tests {
         };
         assert_eq!(status, -1);
     }
+
+    #[test]
+    fn rejects_non_finite_samples() {
+        let samples = [0.0, f64::NAN];
+        let mut avg = 123.0;
+        let mut var = 456.0;
+
+        let status = unsafe {
+            lpmd_histogram_summary(
+                samples.as_ptr(),
+                samples.len(),
+                0.0,
+                1.0,
+                4,
+                &mut avg,
+                &mut var,
+            )
+        };
+
+        assert_eq!(status, -2);
+        assert_eq!(avg, 123.0);
+        assert_eq!(var, 456.0);
+    }
+
+    #[test]
+    fn accepts_null_output_pointers() {
+        let samples = [1.0, 2.0, 3.0];
+
+        let status = unsafe {
+            lpmd_histogram_summary(
+                samples.as_ptr(),
+                samples.len(),
+                0.0,
+                4.0,
+                4,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+        };
+
+        assert_eq!(status, 0);
+    }
+
+    #[test]
+    fn rejects_invalid_ranges_and_bucket_counts() {
+        let samples = [1.0, 2.0, 3.0];
+        let mut avg = 0.0;
+
+        let zero_buckets = unsafe {
+            lpmd_histogram_summary(
+                samples.as_ptr(),
+                samples.len(),
+                0.0,
+                3.0,
+                0,
+                &mut avg,
+                ptr::null_mut(),
+            )
+        };
+        let reversed_range = unsafe {
+            lpmd_histogram_summary(
+                samples.as_ptr(),
+                samples.len(),
+                3.0,
+                0.0,
+                3,
+                &mut avg,
+                ptr::null_mut(),
+            )
+        };
+        let infinite_range = unsafe {
+            lpmd_histogram_summary(
+                samples.as_ptr(),
+                samples.len(),
+                f64::NEG_INFINITY,
+                3.0,
+                3,
+                &mut avg,
+                ptr::null_mut(),
+            )
+        };
+
+        assert_eq!(zero_buckets, -1);
+        assert_eq!(reversed_range, -1);
+        assert_eq!(infinite_range, -1);
+    }
 }

--- a/liblpmd/tests/CMakeLists.txt
+++ b/liblpmd/tests/CMakeLists.txt
@@ -12,10 +12,13 @@ set(LPMD_TEST_UNITS
     colorhandler.unit
     configurationtest.unit
     controlfile.unit
+    elementstest.unit
     fixedsizeparticlesettest.unit
     manipulations.unit
+    matrixtest.unit
     nonorthogonalcelltest.unit
     orthogonalcelltest.unit
+    paramvaluetest.unit
     particlesettest.unit
     propertiestest.unit
     simulationcelltest.unit

--- a/liblpmd/tests/elementstest.unit
+++ b/liblpmd/tests/elementstest.unit
@@ -1,0 +1,29 @@
+#include <lpmd/elements.h>
+
+@testsuite Tests de elementos quimicos
+
+@test Simbolos y numeros atomicos conocidos
+{
+ @equal ElemNum("e"), 0
+ @equal ElemNum("H"), 1
+ @equal ElemNum("C"), 6
+ @equal ElemNum("Fe"), 26
+ @equal ElemNum("Uuo"), 118
+}
+@end
+
+@test Masas atomicas conocidas
+{
+ @approx ElemMass[1], 1.00794, 1.0E-10
+ @approx ElemMass[6], 12.011, 1.0E-10
+ @approx ElemMass[18], 39.948, 1.0E-10
+ @approx ElemMass[79], 196.96654, 1.0E-10
+}
+@end
+
+@test Simbolo desconocido retorna cero
+{
+ @equal ElemNum("Xx"), 0
+ @equal ElemNum(""), 0
+}
+@end

--- a/liblpmd/tests/matrixtest.unit
+++ b/liblpmd/tests/matrixtest.unit
@@ -1,0 +1,163 @@
+#include <sstream>
+#include <string>
+#include <lpmd/error.h>
+#include <lpmd/matrix.h>
+
+using namespace lpmd;
+
+@testsuite Tests de Matrix
+
+@test Constructor por defecto y dimensiones
+{
+ Matrix empty;
+ @equal empty.Rows(), 0
+ @equal empty.Columns(), 0
+ Matrix m(3, 2);
+ @equal m.Columns(), 3
+ @equal m.Rows(), 2
+ for (long row = 0; row < m.Rows(); ++row)
+ {
+  for (long col = 0; col < m.Columns(); ++col)
+  {
+   @approx m.Get(col, row), 0.0, 1.0E-12
+  }
+ }
+}
+@end
+
+@test Set Get y etiquetas de columnas
+{
+ Matrix m(2, 2);
+ m.Set(0, 0, 1.5);
+ m.Set(1, 0, -2.0);
+ m.Set(0, 1, 3.25);
+ m.Set(1, 1, 4.75);
+ m.SetLabel(0, "x");
+ m.SetLabel(1, "energy");
+ @approx m.Get(0, 0), 1.5, 1.0E-12
+ @approx m.Get(1, 0), -2.0, 1.0E-12
+ @approx m.Get(0, 1), 3.25, 1.0E-12
+ @approx m.Get(1, 1), 4.75, 1.0E-12
+ @equal m.GetLabel(0), "x"
+ @equal m.GetLabel(1), "energy"
+}
+@end
+
+@test Copia y asignacion profunda
+{
+ Matrix a(2, 2);
+ a.Set(0, 0, 1.0);
+ a.Set(1, 0, 2.0);
+ a.Set(0, 1, 3.0);
+ a.Set(1, 1, 4.0);
+ a.SetLabel(0, "first");
+ Matrix b(a);
+ Matrix c;
+ c = a;
+ a.Set(0, 0, 99.0);
+ a.SetLabel(0, "changed");
+ @approx b.Get(0, 0), 1.0, 1.0E-12
+ @approx c.Get(0, 0), 1.0, 1.0E-12
+ @equal b.GetLabel(0), "first"
+ @equal c.GetLabel(0), "first"
+}
+@end
+
+@test Suma y escalamiento
+{
+ Matrix a(2, 2), b(2, 2);
+ a.Set(0, 0, 1.0); a.Set(1, 0, 2.0); a.Set(0, 1, 3.0); a.Set(1, 1, 4.0);
+ b.Set(0, 0, 5.0); b.Set(1, 0, 6.0); b.Set(0, 1, 7.0); b.Set(1, 1, 8.0);
+ Matrix s = a + b;
+ @approx s.Get(0, 0), 6.0, 1.0E-12
+ @approx s.Get(1, 0), 8.0, 1.0E-12
+ @approx s.Get(0, 1), 10.0, 1.0E-12
+ @approx s.Get(1, 1), 12.0, 1.0E-12
+ a += b;
+ @approx a.Get(0, 0), 6.0, 1.0E-12
+ Matrix twice = b * 2.0;
+ @approx twice.Get(1, 1), 16.0, 1.0E-12
+ Matrix half = twice / 4.0;
+ @approx half.Get(1, 1), 4.0, 1.0E-12
+}
+@end
+
+@test Suma de matriz vacia adopta dimensiones
+{
+ Matrix empty;
+ Matrix source(1, 2);
+ source.Set(0, 0, 3.0);
+ source.Set(0, 1, 4.0);
+ empty += source;
+ @equal empty.Columns(), 1
+ @equal empty.Rows(), 2
+ @approx empty.Get(0, 0), 3.0, 1.0E-12
+ @approx empty.Get(0, 1), 4.0, 1.0E-12
+}
+@end
+
+@test Determinante con pivote y matriz singular
+{
+ Matrix m(3, 3);
+ m.Set(0, 0, 0.0); m.Set(1, 0, 2.0); m.Set(2, 0, 1.0);
+ m.Set(0, 1, 1.0); m.Set(1, 1, 1.0); m.Set(2, 1, 0.0);
+ m.Set(0, 2, 2.0); m.Set(1, 2, 0.0); m.Set(2, 2, 1.0);
+ @approx m.Det(), -4.0, 1.0E-12
+ Matrix singular(2, 2);
+ singular.Set(0, 0, 1.0); singular.Set(1, 0, 2.0);
+ singular.Set(0, 1, 2.0); singular.Set(1, 1, 4.0);
+ @approx singular.Det(), 0.0, 1.0E-12
+}
+@end
+
+@test Inversa de matriz 2x2
+{
+ Matrix m(2, 2);
+ m.Set(0, 0, 4.0); m.Set(1, 0, 7.0);
+ m.Set(0, 1, 2.0); m.Set(1, 1, 6.0);
+ m.Inverse();
+ @approx m.Get(0, 0), 0.6, 1.0E-12
+ @approx m.Get(1, 0), -0.7, 1.0E-12
+ @approx m.Get(0, 1), -0.2, 1.0E-12
+ @approx m.Get(1, 1), 0.4, 1.0E-12
+}
+@end
+
+@test Operaciones invalidas lanzan excepciones
+{
+ bool threw = false;
+ Matrix a(2, 1), b(1, 2);
+ try { Matrix c = a + b; (void)c; }
+ catch (const InvalidOperation&) { threw = true; }
+ @assert threw
+ threw = false;
+ try { a.Det(); }
+ catch (const InvalidOperation&) { threw = true; }
+ @assert threw
+ threw = false;
+ Matrix singular(2, 2);
+ singular.Set(0, 0, 1.0); singular.Set(1, 0, 2.0);
+ singular.Set(0, 1, 2.0); singular.Set(1, 1, 4.0);
+ try { singular.Inverse(); }
+ catch (const InvalidOperation&) { threw = true; }
+ @assert threw
+}
+@end
+
+@test Operador de salida incluye etiquetas y valores
+{
+ Matrix m(2, 1);
+ m.SetLabel(0, "a");
+ m.SetLabel(1, "b");
+ m.Set(0, 0, 1.25);
+ m.Set(1, 0, -0.5);
+ std::ostringstream os;
+ os << m;
+ const std::string out = os.str();
+ @assert out.find("#") == 0
+ @assert out.find("a") != std::string::npos
+ @assert out.find("b") != std::string::npos
+ @assert out.find("1.250000000000000e+00") != std::string::npos
+ @assert out.find("-5.000000000000000e-01") != std::string::npos
+}
+@end

--- a/liblpmd/tests/paramvaluetest.unit
+++ b/liblpmd/tests/paramvaluetest.unit
@@ -1,0 +1,132 @@
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <lpmd/paramlist.h>
+#include <lpmd/storedvalue.h>
+#include <lpmd/vector.h>
+
+using namespace lpmd;
+
+@testsuite Tests de ParamList y StoredValue
+
+@test Parameter convierte tipos basicos
+{
+ Parameter p("42");
+ int i = p;
+ double d = p;
+ @equal i, 42
+ @approx d, 42.0, 1.0E-12
+ p = "true";
+ bool b = p;
+ @assert b
+ p = "false";
+ b = p;
+ @assert (!b)
+}
+@end
+
+@test ParamList define lee y elimina parametros
+{
+ ParamList pl;
+ @assert (!pl.Defined("temperature"))
+ pl["temperature"] = "300.5";
+ pl["enabled"] = "true";
+ @assert pl.Defined("temperature")
+ @assert pl.Defined("enabled")
+ double t = pl["temperature"];
+ bool enabled = pl["enabled"];
+ @approx t, 300.5, 1.0E-12
+ @assert enabled
+ pl.Remove("enabled");
+ @assert (!pl.Defined("enabled"))
+}
+@end
+
+@test ParamList copia y asigna independientemente
+{
+ ParamList original;
+ original["a"] = "1";
+ original["b"] = "two";
+ ParamList copied(original);
+ ParamList assigned;
+ assigned = original;
+ original["a"] = "99";
+ original.Remove("b");
+ int copied_a = copied["a"];
+ int assigned_a = assigned["a"];
+ @equal copied_a, 1
+ @equal assigned_a, 1
+ @assert copied.Defined("b")
+ @assert assigned.Defined("b")
+ @equal copied["b"], "two"
+ @equal assigned["b"], "two"
+}
+@end
+
+@test ParamList enumera parametros ordenados por clave
+{
+ ParamList pl;
+ pl["zeta"] = "last";
+ pl["alpha"] = "first";
+ pl["middle"] = "center";
+ Array<Parameter> params = pl.Parameters();
+ @equal params.Size(), 3
+ @equal params[0], "alpha"
+ @equal params[1], "middle"
+ @equal params[2], "zeta"
+}
+@end
+
+@test StoredValue promedia numeros y reinicia
+{
+ StoredValue<double> value;
+ std::ostringstream os;
+ value.OutputAverageTo(os);
+ @equal os.str(), "0"
+ value.CurrentValue() = 2.0;
+ value.AddToAverage();
+ value.CurrentValue() = 4.0;
+ value.AddToAverage();
+ os.str("");
+ os.clear();
+ value.OutputTo(os);
+ @equal os.str(), "4"
+ os.str("");
+ os.clear();
+ value.OutputAverageTo(os);
+ @equal os.str(), "3"
+ value.ClearAverage();
+ os.str("");
+ os.clear();
+ value.OutputAverageTo(os);
+ @equal os.str(), "0"
+}
+@end
+
+@test StoredValue promedia vectores
+{
+ StoredValue<Vector> value;
+ value.CurrentValue() = Vector(1.0, 2.0, 3.0);
+ value.AddToAverage();
+ value.CurrentValue() = Vector(3.0, 4.0, 5.0);
+ value.AddToAverage();
+ std::ostringstream os;
+ value.OutputAverageTo(os);
+ @equal os.str(), "2 3 4"
+}
+@end
+
+@test AbstractValue escribe a archivo
+{
+ StoredValue<double> value;
+ value.CurrentValue() = 12.5;
+ const std::string filename = "storedvalue_output.tmp";
+ value.OutputToFile(filename);
+ std::ifstream input(filename.c_str());
+ std::string content;
+ input >> content;
+ input.close();
+ std::remove(filename.c_str());
+ @equal content, "12.5"
+}
+@end


### PR DESCRIPTION
### Motivation

- Increase automated coverage to validate core helpers (matrix, param/values, elements) and FFI histogram behavior. 
- Catch regressions early by exercising copy/assignment, arithmetic, error handling and I/O code paths. 

### Description

- Added three new C++ LPUnit test suites: `liblpmd/tests/matrixtest.unit`, `liblpmd/tests/paramvaluetest.unit`, and `liblpmd/tests/elementstest.unit`. 
- Registered the new `.unit` files in `liblpmd/tests/CMakeLists.txt` so generated tests are built and run with the `liblpmd_unit_tests` target. 
- Expanded Rust tests in `liblpmd/rust/src/lib.rs` to cover non-finite samples, null output pointers, and invalid ranges/bucket counts for `lpmd_histogram_summary`. 
- Adjusted one matrix expectation to match current implementation (determinant expected value changed to `-4.0`).

### Testing

- Generated, built and ran the C++ unit tests with `cmake --build build --target liblpmd_unit_tests -j2` and `ctest --test-dir build --output-on-failure`, resulting in all C++ tests passing (22/22) after the matrix expectation adjustment. 
- Ran Rust unit tests with `cargo test` in `liblpmd/rust` and observed all added tests passing. 
- Build and basic sanity checks (`git diff --check`) executed with no formatting or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07ac0e86c883209b7932f8422ed39d)