### PR TITLE
Fix plugin keyword probing and guard cell-manager lookup

### DIFF
--- a/liblpmd/plugins/pluginmanager.cc
+++ b/liblpmd/plugins/pluginmanager.cc
@@ -173,9 +173,9 @@ void PluginManager::UpdatePlugin(std::string id, std::string new_args) {
 
 std::string PluginManager::GetPluginKeywords(std::string name) {
   if (aliasdict.Defined(name))
-    LoadPlugin(aliasdict[name], "tmp_getpluginkeywords", "dummyargument");
+    LoadPlugin(aliasdict[name], "tmp_getpluginkeywords", "");
   else
-    LoadPlugin(name, "tmp_getpluginkeywords", "dummyargument");
+    LoadPlugin(name, "tmp_getpluginkeywords", "");
   Plugin* m = modules["tmp_getpluginkeywords"].get();
   std::string kw = m->Keywords();
   UnloadPlugin("tmp_getpluginkeywords");

--- a/lpmd/lpmd.cc
+++ b/lpmd/lpmd.cc
@@ -34,8 +34,10 @@ void LPMD::FillAtoms() {
     RestoreSimulation();
   else
     Application::FillAtoms();
-  PrintBanner("CELL MANAGER");
-  pluginmanager[control["cellmanager-module"]].Show(std::cout);
+  if (control.Defined("cellmanager-module")) {
+    PrintBanner("CELL MANAGER");
+    pluginmanager[control["cellmanager-module"]].Show(std::cout);
+  }
   PrintBanner("INITIAL CONFIGURATION");
   simulation->ShowInfo(std::cout);
 }


### PR DESCRIPTION
### Motivation
- Avoid loading temporary plugins with a placeholder argument that plugins may parse and fail on, causing keyword probing to break.
- Prevent `lpmd` from attempting to show a cell-manager when none is configured, which can trigger invalid lookups during startup or example runs.

### Description
- In `liblpmd/plugins/pluginmanager.cc` changed `GetPluginKeywords` to load the temporary plugin with an empty argument string instead of the placeholder `"dummyargument"` to avoid constructor parsing issues when probing keywords. 
- In `lpmd/lpmd.cc` added a guard so the cell-manager banner and `Show` call are executed only if `control.Defined("cellmanager-module")` to avoid accessing an empty plugin id.
- Small commit recorded with the two-file patch applying the above fixes.

### Testing
- Built the project with `cmake -S . -B build && cmake --build build -j"$(nproc)"` and the build completed successfully (CMake emitted OpenGL/GLUT warnings for skipped visual plugins). 
- Ran the unit test suite with `ctest --test-dir build --output-on-failure` and all 22 tests passed. 
- Performed an example usability run by creating and running a minimal control file with `/workspace/lpmd2/build/bin/lpmd simple.control`, which exited `0` and produced a `simple.xyz` output file of 130 lines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07b16e5d608320a549869f1c78acb7)