### PR TITLE
Add headless smoke example and document smoke-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ For a more detailed walkthrough of verifying the compilation outputs, see
 
 ## Running
 
-Run the simulator and let it locate the default plugin automatically:
+Run the headless smoke example to confirm the executable can locate plugins,
+generate a small crystal, advance one step, and write an XYZ file:
 
 ```bash
-./build/bin/lpmd
+mkdir -p /tmp/lpmd-smoke-run
+cd /tmp/lpmd-smoke-run
+/path/to/lpmd2/build/bin/lpmd /path/to/lpmd2/lpmd/examples/smoke.control
 ```
 
-You can also specify a plugin explicitly:
-
-```bash
-./build/bin/lpmd /path/to/plugin
-```
+The run should finish with `SIMULATION FINISHED` and write `smoke.xyz` in the
+working directory.
 
 ## Project layout
 

--- a/docs/COMPILATION.md
+++ b/docs/COMPILATION.md
@@ -30,6 +30,19 @@ The build should finish without errors, producing the following artifacts:
 These paths match the default output configuration of the CMake project and
 confirm that the compilation stage completed successfully.
 
+## Smoke example
+
+After building, run the minimal headless example from a scratch directory so
+generated files do not dirty the checkout:
+
+```bash
+mkdir -p /tmp/lpmd-smoke-run
+cd /tmp/lpmd-smoke-run
+/path/to/lpmd2/build/bin/lpmd /path/to/lpmd2/lpmd/examples/smoke.control
+```
+
+A successful run prints `SIMULATION FINISHED` and writes `smoke.xyz`.
+
 ## Testing
 
 Unit tests are gated behind the `LPMD_ENABLE_TESTS` CMake option. To compile

--- a/lpmd/examples/smoke.control
+++ b/lpmd/examples/smoke.control
@@ -1,0 +1,23 @@
+# Minimal headless smoke example for checking that the command line application,
+# plugin loader, crystal generator, cell manager, integrator, and XYZ writer work
+# together after a build. It completes in one step and writes smoke.xyz.
+
+cell cubic 17.1191
+input crystal3d type=fcc symbol=Ar nx=1 ny=1 nz=1
+output xyz file=smoke.xyz each=1
+
+steps 1
+
+use nullpotential as none
+enduse
+
+use nullintegrator as integ
+enduse
+
+use minimumimage as cm
+    cutoff 8.0
+enduse
+
+cellmanager cm
+potential none Ar Ar
+integrator integ


### PR DESCRIPTION
### Motivation

- Provide a tiny, deterministic post-build verification that exercises the runtime plugin loader and basic execution path without relying on interactive visualizers or long examples. 

### Description

- Add `lpmd/examples/smoke.control`, a one-step headless control file that generates a small crystal, uses a no-op potential/integrator and the `minimumimage` cell manager, and writes `smoke.xyz`.
- Update `README.md` to point users at the smoke example as a simple post-build usability check using a scratch directory.
- Update `docs/COMPILATION.md` to document running the smoke example as a lightweight smoke test after building.

### Testing

- Configured and built the project with tests enabled using `cmake -S . -B build -DLPMD_ENABLE_TESTS=ON` and `cmake --build build -j2`, which completed successfully.
- Ran the unit test suite with `ctest --test-dir build --output-on-failure`, with `22/22` tests passing.
- Executed the smoke scenario in a scratch directory with `/path/to/build/bin/lpmd /path/to/lpmd/examples/smoke.control`, which finished and produced `smoke.xyz` and printed `SIMULATION FINISHED` (run verified file exists and contains 4 atoms).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07b3d0036c8320a5ad6e8304fd81a1)