### PR TITLE
Limit clang-format workflow to changed files

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -22,6 +22,7 @@ on:
       - '**/*.hpp'
       - '**/*.hh'
       - '.clang-format'
+      - '.github/workflows/clang-format.yml'
 
 jobs:
   format:
@@ -29,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install clang-format
         run: |
@@ -36,8 +39,27 @@ jobs:
           sudo apt-get install -y clang-format-15
 
       - name: Check formatting
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          FILES=$(git ls-files '*.c' '*.cc' '*.cxx' '*.cpp' '*.h' '*.hh' '*.hpp')
-          if [ -n "$FILES" ]; then
-            clang-format-15 --dry-run --Werror $FILES
+          set -euo pipefail
+
+          if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            git fetch --no-tags --depth=1 origin "${DEFAULT_BRANCH}"
+            BASE_SHA=$(git merge-base "HEAD" "origin/${DEFAULT_BRANCH}")
           fi
+
+          mapfile -d '' FILES < <(
+            git diff --name-only --diff-filter=ACMRT -z "${BASE_SHA}" HEAD -- \
+              '*.c' '*.cc' '*.cxx' '*.cpp' '*.h' '*.hh' '*.hpp'
+          )
+
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "No changed C/C++ files to format."
+            exit 0
+          fi
+
+          printf 'Checking clang-format for:\n'
+          printf '  %s\n' "${FILES[@]}"
+          clang-format-15 --dry-run --Werror "${FILES[@]}"


### PR DESCRIPTION
### Motivation
- The Clang-Format job was failing on every PR because it checked every C/C++ file in the repo (including legacy files with formatting violations). 
- The workflow needed a reliable way to compute the PR base commit and to run when the workflow file itself is changed so changes to the workflow are validated.

### Description
- Include `.github/workflows/clang-format.yml` in the workflow `paths` so modifying the workflow triggers the job. 
- Set `fetch-depth: 0` for `actions/checkout` so `git merge-base` can compute a proper base commit. 
- Compute `BASE_SHA` from the PR base or from `github.event.before` and fetch the default branch when the base is missing, using `git merge-base` to find the comparison point. 
- Build `FILES` with `git diff --name-only --diff-filter=ACMRT -z "${BASE_SHA}" HEAD` and run `clang-format-15 --dry-run --Werror` only on those changed C/C++ files, exiting cleanly if there are no changed files.

### Testing
- Ran the updated shell logic locally with `BASE_SHA=HEAD` and `DEFAULT_BRANCH=...` and it exited successfully when no C/C++ files changed (success). 
- Ran `git diff --check` to validate repository diffs (success). 
- Parsed the workflow YAML with Ruby via `YAML.load_file('.github/workflows/clang-format.yml')` to confirm valid YAML (success). 
- Attempting to run `clang-format-15` across the entire repo in this environment failed because `clang-format-15` was not installed and the fallback `clang-format` reported many formatting violations (failure), which is the issue this change avoids by only checking changed files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0847ab90bc8320aa9ce93ea21263bf)