### PR TITLE
Add experimental Rust hotspot helpers and integrate with minimumimage plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 include(CTest)
 option(LPMD_ENABLE_TESTS "Build lpmd unit tests" ${BUILD_TESTING})
+option(LPMD_ENABLE_RUST_HOTSPOTS "Build experimental Rust hotspot helpers" OFF)
 if(LPMD_ENABLE_TESTS)
     enable_testing()
 endif()

--- a/liblpmd/rust/README.md
+++ b/liblpmd/rust/README.md
@@ -13,9 +13,10 @@ Rust se llama [`csta`](https://crates.io/crates/csta), no `cesta`.
 - **Qué añade LPMD encima:** el crate local `lpmd_stats` expone una función C
   ABI llamada `lpmd_histogram_summary` para que, en el futuro, código C o C++
   pueda pedir ese resumen estadístico sin conocer Rust.
-- **Estado actual:** el crate Rust compila y se prueba de forma independiente,
-  pero todavía **no está enlazado por CMake ni invocado por el flujo normal de
-  `lpmd`, `lpmd-analyzer`, `lpmd-converter` o los plugins C++**.
+- **Estado actual:** el crate Rust compila y se prueba de forma independiente.
+  Además, CMake puede enlazarlo de forma experimental con el plugin
+  `minimumimage` cuando se configura `-DLPMD_ENABLE_RUST_HOTSPOTS=ON`; el flujo
+  normal lo mantiene desactivado por defecto.
 
 ## ¿Qué problema intenta resolver?
 
@@ -108,6 +109,30 @@ pub unsafe extern "C" fn lpmd_histogram_summary(
 - La función no reserva ni libera memoria para el llamador; solo escribe valores
   escalares en los punteros de salida.
 
+## Hotspot experimental: lista de vecinos ortogonal
+
+El crate también expone `lpmd_build_neighbor_list_orthogonal`, una función C ABI
+para construir, por lotes, la lista de vecinos de un átomo en una celda
+ortogonal usando buffers planos:
+
+- entrada: posiciones `x, y, z` contiguas, longitudes de celda, periodicidad,
+  índice central, `cutoff` y modo `full`;
+- salida: índices vecinos, vectores `rij`, distancias cuadradas `r2` y contador
+  de resultados;
+- ownership: C/C++ reserva y libera todos los buffers; Rust solo valida y
+  escribe resultados.
+
+Esta ruta se usa desde `plugins/minimumimage.cc` solo cuando el build activa
+`LPMD_ENABLE_RUST_HOTSPOTS`. Si Rust rechaza los datos o la celda no es
+ortogonal, el plugin cae al camino C++ existente.
+
+Para compilar la PoC desde la raíz del repositorio:
+
+```bash
+cmake -S . -B build-rust-hotspots -DCMAKE_BUILD_TYPE=Release -DLPMD_ENABLE_RUST_HOTSPOTS=ON
+cmake --build build-rust-hotspots --target plugin_minimumimage
+```
+
 ## Cómo se compila y se prueba hoy
 
 Desde este directorio:
@@ -141,8 +166,8 @@ El artefacto esperado queda bajo `liblpmd/rust/target/release/`, por ejemplo
 
 ## Cómo se incorporaría desde C/C++
 
-Aunque el flujo CMake actual todavía no lo hace automáticamente, la función fue
-escrita para poder llamarse desde C o C++ mediante una declaración compatible:
+La función de histograma puede llamarse desde C o C++ mediante una declaración
+compatible:
 
 ```cpp
 #include <cstddef>

--- a/liblpmd/rust/include/lpmd/rust_hotspots.h
+++ b/liblpmd/rust/include/lpmd/rust_hotspots.h
@@ -1,0 +1,17 @@
+#ifndef LPMD_RUST_HOTSPOTS_H
+#define LPMD_RUST_HOTSPOTS_H
+
+#include <cstddef>
+#include <cstdint>
+
+extern "C" int lpmd_histogram_summary(const double* data, std::size_t len, double range_min,
+                                       double range_max, std::size_t buckets,
+                                       double* out_average, double* out_variance);
+
+extern "C" int lpmd_build_neighbor_list_orthogonal(
+    const double* positions_xyz, std::size_t atom_count, std::size_t center_index,
+    const double* cell_lengths, const std::uint8_t* periodic, double cutoff, int full,
+    std::size_t* out_indices, double* out_rij_xyz, double* out_r2, std::size_t capacity,
+    std::size_t* out_count);
+
+#endif // LPMD_RUST_HOTSPOTS_H

--- a/liblpmd/rust/src/lib.rs
+++ b/liblpmd/rust/src/lib.rs
@@ -70,9 +70,194 @@ pub unsafe extern "C" fn lpmd_histogram_summary(
     0
 }
 
+/// Build the minimum-image neighbor list for one atom in an orthogonal cell.
+///
+/// The function is intentionally shaped as a C ABI batch primitive: C++ owns all memory,
+/// Rust receives plain arrays, and Rust fills preallocated output buffers with the
+/// neighbor index, displacement vector, and squared distance for every pair that falls
+/// inside `cutoff`.
+///
+/// # Safety
+///
+/// - `positions_xyz` must point to `atom_count * 3` consecutive `f64` values laid out as
+///   `x0, y0, z0, x1, y1, z1, ...`.
+/// - `cell_lengths` must point to three finite positive `f64` values.
+/// - `periodic` must point to three bytes, where zero means non-periodic and non-zero
+///   means periodic.
+/// - Output arrays must point to at least `capacity`, `capacity * 3`, and `capacity`
+///   writable elements respectively, unless `capacity == 0`.
+/// - `out_count` must be a valid writable pointer.
+///
+/// # Return codes
+///
+/// - `0`: success.
+/// - `-1`: invalid pointer, range, atom index, cutoff, or non-finite input.
+/// - `-2`: output capacity is too small; `out_count` is set to the required number of
+///   entries when possible.
+#[no_mangle]
+pub unsafe extern "C" fn lpmd_build_neighbor_list_orthogonal(
+    positions_xyz: *const f64,
+    atom_count: usize,
+    center_index: usize,
+    cell_lengths: *const f64,
+    periodic: *const u8,
+    cutoff: f64,
+    full: i32,
+    out_indices: *mut usize,
+    out_rij_xyz: *mut f64,
+    out_r2: *mut f64,
+    capacity: usize,
+    out_count: *mut usize,
+) -> i32 {
+    if positions_xyz.is_null()
+        || cell_lengths.is_null()
+        || periodic.is_null()
+        || out_count.is_null()
+        || atom_count == 0
+        || center_index >= atom_count
+        || !cutoff.is_finite()
+        || cutoff <= 0.0
+    {
+        return -1;
+    }
+
+    if capacity > 0 && (out_indices.is_null() || out_rij_xyz.is_null() || out_r2.is_null()) {
+        return -1;
+    }
+
+    let positions = unsafe { slice::from_raw_parts(positions_xyz, atom_count * 3) };
+    let cell = unsafe { slice::from_raw_parts(cell_lengths, 3) };
+    let periodic = unsafe { slice::from_raw_parts(periodic, 3) };
+
+    if cell.iter().any(|value| !value.is_finite() || *value <= 0.0) {
+        return -1;
+    }
+
+    let cutoff2 = cutoff * cutoff;
+    if !cutoff2.is_finite() {
+        return -1;
+    }
+
+    let center_offset = center_index * 3;
+    let center = [
+        positions[center_offset],
+        positions[center_offset + 1],
+        positions[center_offset + 2],
+    ];
+    if center.iter().any(|value| !value.is_finite()) {
+        return -1;
+    }
+
+    let include_all_pairs = full != 0;
+    let start = if include_all_pairs {
+        0
+    } else {
+        center_index + 1
+    };
+    let mut count = 0usize;
+    for atom_index in start..atom_count {
+        if atom_index == center_index {
+            continue;
+        }
+
+        let offset = atom_index * 3;
+        let candidate = [
+            positions[offset],
+            positions[offset + 1],
+            positions[offset + 2],
+        ];
+        if candidate.iter().any(|value| !value.is_finite()) {
+            return -1;
+        }
+        let mut displacement = [
+            candidate[0] - center[0],
+            candidate[1] - center[1],
+            candidate[2] - center[2],
+        ];
+
+        for axis in 0..3 {
+            if periodic[axis] == 0 {
+                continue;
+            }
+            let length = cell[axis];
+            let half = 0.5 * length;
+            if displacement[axis] >= half {
+                displacement[axis] -= length;
+            } else if displacement[axis] < -half {
+                displacement[axis] += length;
+            }
+        }
+
+        let r2 = displacement[0] * displacement[0]
+            + displacement[1] * displacement[1]
+            + displacement[2] * displacement[2];
+
+        if r2 < cutoff2 {
+            if count >= capacity {
+                let mut required = count + 1;
+                for rest_index in (atom_index + 1)..atom_count {
+                    if !include_all_pairs && rest_index <= center_index {
+                        continue;
+                    }
+                    let rest_offset = rest_index * 3;
+                    let rest_candidate = [
+                        positions[rest_offset],
+                        positions[rest_offset + 1],
+                        positions[rest_offset + 2],
+                    ];
+                    if rest_candidate.iter().any(|value| !value.is_finite()) {
+                        return -1;
+                    }
+                    let mut rest_displacement = [
+                        rest_candidate[0] - center[0],
+                        rest_candidate[1] - center[1],
+                        rest_candidate[2] - center[2],
+                    ];
+                    for axis in 0..3 {
+                        if periodic[axis] == 0 {
+                            continue;
+                        }
+                        let length = cell[axis];
+                        let half = 0.5 * length;
+                        if rest_displacement[axis] >= half {
+                            rest_displacement[axis] -= length;
+                        } else if rest_displacement[axis] < -half {
+                            rest_displacement[axis] += length;
+                        }
+                    }
+                    let rest_r2 = rest_displacement[0] * rest_displacement[0]
+                        + rest_displacement[1] * rest_displacement[1]
+                        + rest_displacement[2] * rest_displacement[2];
+                    if rest_r2 < cutoff2 {
+                        required += 1;
+                    }
+                }
+                unsafe {
+                    ptr::write(out_count, required);
+                }
+                return -2;
+            }
+
+            unsafe {
+                ptr::write(out_indices.add(count), atom_index);
+                ptr::write(out_rij_xyz.add(count * 3), displacement[0]);
+                ptr::write(out_rij_xyz.add(count * 3 + 1), displacement[1]);
+                ptr::write(out_rij_xyz.add(count * 3 + 2), displacement[2]);
+                ptr::write(out_r2.add(count), r2);
+            }
+            count += 1;
+        }
+    }
+
+    unsafe {
+        ptr::write(out_count, count);
+    }
+    0
+}
+
 #[cfg(test)]
 mod tests {
-    use super::lpmd_histogram_summary;
+    use super::{lpmd_build_neighbor_list_orthogonal, lpmd_histogram_summary};
     use std::ptr;
 
     #[test]
@@ -191,5 +376,106 @@ mod tests {
         assert_eq!(zero_buckets, -1);
         assert_eq!(reversed_range, -1);
         assert_eq!(infinite_range, -1);
+    }
+
+    #[test]
+    fn builds_half_neighbor_list_with_minimum_image() {
+        let positions = [
+            0.0, 0.0, 0.0, // center
+            1.0, 0.0, 0.0, // direct neighbor
+            9.5, 0.0, 0.0, // periodic neighbor at -0.5
+            5.0, 0.0, 0.0, // outside cutoff
+        ];
+        let cell = [10.0, 10.0, 10.0];
+        let periodic = [1_u8, 1, 1];
+        let mut indices = [0_usize; 4];
+        let mut rij = [0.0_f64; 12];
+        let mut r2 = [0.0_f64; 4];
+        let mut count = 0_usize;
+
+        let status = unsafe {
+            lpmd_build_neighbor_list_orthogonal(
+                positions.as_ptr(),
+                4,
+                0,
+                cell.as_ptr(),
+                periodic.as_ptr(),
+                2.0,
+                0,
+                indices.as_mut_ptr(),
+                rij.as_mut_ptr(),
+                r2.as_mut_ptr(),
+                indices.len(),
+                &mut count,
+            )
+        };
+
+        assert_eq!(status, 0);
+        assert_eq!(count, 2);
+        assert_eq!(&indices[..count], &[1, 2]);
+        assert_eq!(&rij[..3], &[1.0, 0.0, 0.0]);
+        assert_eq!(&rij[3..6], &[-0.5, 0.0, 0.0]);
+        assert!((r2[0] - 1.0).abs() < 1e-12);
+        assert!((r2[1] - 0.25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn full_neighbor_list_skips_center_atom() {
+        let positions = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -1.0, 0.0, 0.0];
+        let cell = [10.0, 10.0, 10.0];
+        let periodic = [0_u8, 0, 0];
+        let mut indices = [0_usize; 3];
+        let mut rij = [0.0_f64; 9];
+        let mut r2 = [0.0_f64; 3];
+        let mut count = 0_usize;
+
+        let status = unsafe {
+            lpmd_build_neighbor_list_orthogonal(
+                positions.as_ptr(),
+                3,
+                1,
+                cell.as_ptr(),
+                periodic.as_ptr(),
+                3.0,
+                1,
+                indices.as_mut_ptr(),
+                rij.as_mut_ptr(),
+                r2.as_mut_ptr(),
+                indices.len(),
+                &mut count,
+            )
+        };
+
+        assert_eq!(status, 0);
+        assert_eq!(count, 2);
+        assert_eq!(&indices[..count], &[0, 2]);
+    }
+
+    #[test]
+    fn reports_required_neighbor_capacity() {
+        let positions = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+        let cell = [10.0, 10.0, 10.0];
+        let periodic = [0_u8, 0, 0];
+        let mut count = 0_usize;
+
+        let status = unsafe {
+            lpmd_build_neighbor_list_orthogonal(
+                positions.as_ptr(),
+                2,
+                0,
+                cell.as_ptr(),
+                periodic.as_ptr(),
+                2.0,
+                0,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                0,
+                &mut count,
+            )
+        };
+
+        assert_eq!(status, -2);
+        assert_eq!(count, 1);
     }
 }

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -28,6 +28,29 @@ find_package(ZLIB REQUIRED)
 find_package(OpenGL)
 find_package(GLUT)
 
+
+if(LPMD_ENABLE_RUST_HOTSPOTS)
+    find_program(CARGO_EXECUTABLE cargo REQUIRED)
+    set(LPMD_RUST_DIR "${CMAKE_SOURCE_DIR}/liblpmd/rust")
+    set(LPMD_RUST_CDYLIB "${LPMD_RUST_DIR}/target/release/${CMAKE_SHARED_LIBRARY_PREFIX}lpmd_stats${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(LPMD_RUST_BUILD_LIB "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_SHARED_LIBRARY_PREFIX}lpmd_stats${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+    add_custom_command(
+        OUTPUT "${LPMD_RUST_BUILD_LIB}"
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        COMMAND "${CARGO_EXECUTABLE}" build --release --manifest-path "${LPMD_RUST_DIR}/Cargo.toml"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${LPMD_RUST_CDYLIB}" "${LPMD_RUST_BUILD_LIB}"
+        DEPENDS
+            "${LPMD_RUST_DIR}/Cargo.toml"
+            "${LPMD_RUST_DIR}/Cargo.lock"
+            "${LPMD_RUST_DIR}/src/lib.rs"
+            "${LPMD_RUST_DIR}/include/lpmd/rust_hotspots.h"
+        COMMENT "Building experimental Rust hotspot helpers"
+        VERBATIM
+    )
+    add_custom_target(lpmd_rust_hotspots DEPENDS "${LPMD_RUST_BUILD_LIB}")
+endif()
+
 set(HAVE_OPENGL OFF)
 if(OpenGL_FOUND AND GLUT_FOUND)
     set(HAVE_OPENGL ON)
@@ -75,5 +98,15 @@ foreach(plugin_src ${PLUGIN_SOURCES})
 
     if(plugin_name IN_LIST OPENGL_PLUGINS)
         target_link_libraries(${plugin_target} PRIVATE OpenGL::GL OpenGL::GLU GLUT::GLUT)
+    endif()
+
+    if(LPMD_ENABLE_RUST_HOTSPOTS AND plugin_name STREQUAL "minimumimage")
+        add_dependencies(${plugin_target} lpmd_rust_hotspots)
+        target_compile_definitions(${plugin_target} PRIVATE LPMD_ENABLE_RUST_HOTSPOTS=1)
+        target_include_directories(${plugin_target} PRIVATE "${LPMD_RUST_DIR}/include")
+        target_link_libraries(${plugin_target} PRIVATE "${LPMD_RUST_BUILD_LIB}")
+        if(UNIX AND NOT APPLE)
+            set_property(TARGET ${plugin_target} APPEND PROPERTY BUILD_RPATH "\$ORIGIN")
+        endif()
     endif()
 endforeach()

--- a/plugins/minimumimage.cc
+++ b/plugins/minimumimage.cc
@@ -6,6 +6,12 @@
 #include <lpmd/configuration.h>
 
 #include <cmath>
+#include <cstdint>
+#include <vector>
+
+#ifdef LPMD_ENABLE_RUST_HOTSPOTS
+#include <lpmd/rust_hotspots.h>
+#endif
 
 using namespace lpmd;
 
@@ -65,10 +71,8 @@ void MinimumImageCellManager::UpdateAtom(Configuration& conf, long i) { UpdateCe
 
 double MinimumImageCellManager::Cutoff() const { return rcut; }
 
-void MinimumImageCellManager::BuildNeighborList(Configuration& conf, long i, NeighborList& nlist,
-                                                bool full, double rcu) {
-  if (rcu < 1.0E-10)
-    EndWithError("MinimumImage cutoff equals zero...");
+namespace {
+void BuildNeighborListCpp(Configuration& conf, long i, NeighborList& nlist, bool full, double rcu) {
   BasicParticleSet& atoms = conf.Atoms();
   BasicCell& cell = conf.Cell();
   const long int n = atoms.Size();
@@ -97,6 +101,66 @@ void MinimumImageCellManager::BuildNeighborList(Configuration& conf, long i, Nei
         nlist.Append(nn);
     }
   }
+}
+} // namespace
+
+void MinimumImageCellManager::BuildNeighborList(Configuration& conf, long i, NeighborList& nlist,
+                                                bool full, double rcu) {
+  if (rcu < 1.0E-10)
+    EndWithError("MinimumImage cutoff equals zero...");
+
+#ifdef LPMD_ENABLE_RUST_HOTSPOTS
+  BasicParticleSet& atoms = conf.Atoms();
+  BasicCell& cell = conf.Cell();
+  const long int n = atoms.Size();
+
+  if (cell.IsOrthogonal() && i >= 0 && i < n) {
+    std::vector<double> positions(static_cast<std::size_t>(n) * 3);
+    for (long int atom_index = 0; atom_index < n; ++atom_index) {
+      const Vector& position = atoms[atom_index].Position();
+      const std::size_t offset = static_cast<std::size_t>(atom_index) * 3;
+      positions[offset] = position[0];
+      positions[offset + 1] = position[1];
+      positions[offset + 2] = position[2];
+    }
+
+    double cell_lengths[3] = {cell[0][0], cell[1][1], cell[2][2]};
+    std::uint8_t periodic[3] = {static_cast<std::uint8_t>(cell.Periodicity(0)),
+                                static_cast<std::uint8_t>(cell.Periodicity(1)),
+                                static_cast<std::uint8_t>(cell.Periodicity(2))};
+    const std::size_t capacity =
+        full ? (n > 0 ? static_cast<std::size_t>(n - 1) : 0)
+             : (i + 1 < n ? static_cast<std::size_t>(n - i - 1) : 0);
+    std::vector<std::size_t> indices(capacity);
+    std::vector<double> rij(capacity * 3);
+    std::vector<double> r2(capacity);
+    std::size_t count = 0;
+
+    const int status = lpmd_build_neighbor_list_orthogonal(
+        positions.data(), static_cast<std::size_t>(n), static_cast<std::size_t>(i), cell_lengths,
+        periodic, rcu, full ? 1 : 0, capacity > 0 ? indices.data() : nullptr,
+        capacity > 0 ? rij.data() : nullptr, capacity > 0 ? r2.data() : nullptr, capacity, &count);
+
+    if (status == 0) {
+      nlist.Clear();
+      AtomPair nn;
+      nn.i = &atoms[i];
+      nn.i_index = i;
+      for (std::size_t k = 0; k < count; ++k) {
+        const long int j = static_cast<long int>(indices[k]);
+        nn.j = &(atoms[j]);
+        nn.j_index = j;
+        const std::size_t offset = k * 3;
+        nn.rij = Vector(rij[offset], rij[offset + 1], rij[offset + 2]);
+        nn.r2 = r2[k];
+        nlist.Append(nn);
+      }
+      return;
+    }
+  }
+#endif
+
+  BuildNeighborListCpp(conf, i, nlist, full, rcu);
 }
 
 // Esto se incluye para que el modulo pueda ser cargado dinamicamente


### PR DESCRIPTION
### Motivation

- Enable an experimental path to implement performance‑critical hotspots in Rust while keeping the C/C++ codebase unchanged by exposing a C ABI surface.
- Provide a first Rust hotspot for statistics (`lpmd_histogram_summary`) and a PoC neighbor‑list builder (`lpmd_build_neighbor_list_orthogonal`) that can be wired into the `minimumimage` plugin.
- Keep the Rust integration opt‑in and non‑disruptive via a CMake toggle so the default build remains C++ only.

### Description

- Add a new CMake option `LPMD_ENABLE_RUST_HOTSPOTS` and wire the Rust crate build into the plugins build when enabled by adding a custom build step and target.
- Extend `plugins/CMakeLists.txt` to build and copy the Rust `cdylib` and to link/include it into the `minimumimage` plugin when the option is set.
- Add a C header `liblpmd/rust/include/lpmd/rust_hotspots.h` that declares the C ABI functions (`lpmd_histogram_summary` and `lpmd_build_neighbor_list_orthogonal`).
- Implement `lpmd_build_neighbor_list_orthogonal` in `liblpmd/rust/src/lib.rs` as an unsafe C ABI function that builds a minimum‑image neighbor list for orthogonal cells and returns detailed status codes, and keep existing histogram function exports.
- Update `liblpmd/rust/README.md` to document the crate, the experimental hotspot, usage, and build instructions for the PoC.
- Modify `plugins/minimumimage.cc` to call the Rust neighbor‑list function when `LPMD_ENABLE_RUST_HOTSPOTS` is defined and the cell is orthogonal, and fall back to the original C++ implementation otherwise.
- Add Rust unit tests for both the histogram and the new neighbor‑list functions inside `liblpmd/rust/src/lib.rs`.

### Testing

- Ran `cargo test` from `liblpmd/rust` to execute the Rust unit tests, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08e74bef5c8320b625bfefd9fa2afb)