### PR TITLE
Add Rust Lennard-Jones batch hotspot and integrate with C++ plugins; neighbor-list caching

### DIFF
--- a/liblpmd/rust/include/lpmd/rust_hotspots.h
+++ b/liblpmd/rust/include/lpmd/rust_hotspots.h
@@ -5,13 +5,20 @@
 #include <cstdint>
 
 extern "C" int lpmd_histogram_summary(const double* data, std::size_t len, double range_min,
-                                       double range_max, std::size_t buckets,
-                                       double* out_average, double* out_variance);
+                                      double range_max, std::size_t buckets, double* out_average,
+                                      double* out_variance);
 
-extern "C" int lpmd_build_neighbor_list_orthogonal(
-    const double* positions_xyz, std::size_t atom_count, std::size_t center_index,
-    const double* cell_lengths, const std::uint8_t* periodic, double cutoff, int full,
-    std::size_t* out_indices, double* out_rij_xyz, double* out_r2, std::size_t capacity,
-    std::size_t* out_count);
+extern "C" int lpmd_build_neighbor_list_orthogonal(const double* positions_xyz,
+                                                   std::size_t atom_count, std::size_t center_index,
+                                                   const double* cell_lengths,
+                                                   const std::uint8_t* periodic, double cutoff,
+                                                   int full, std::size_t* out_indices,
+                                                   double* out_rij_xyz, double* out_r2,
+                                                   std::size_t capacity, std::size_t* out_count);
+
+extern "C" int lpmd_lennard_jones_batch(const double* rij_xyz, const double* r2, std::size_t count,
+                                        double sigma, double epsilon, double cutoff,
+                                        double* out_force_xyz, double* out_energy,
+                                        double* out_virial, double* out_stress);
 
 #endif // LPMD_RUST_HOTSPOTS_H

--- a/liblpmd/rust/src/lib.rs
+++ b/liblpmd/rust/src/lib.rs
@@ -255,9 +255,122 @@ pub unsafe extern "C" fn lpmd_build_neighbor_list_orthogonal(
     0
 }
 
+/// Compute Lennard-Jones pair energies, force vectors, virial, and stress terms in batch.
+///
+/// `rij_xyz` and `r2` describe `count` already-filtered pair displacements. C++ owns the
+/// buffers; Rust only validates inputs and writes per-pair forces plus accumulated scalar
+/// and tensor contributions.
+///
+/// # Safety
+///
+/// - `rij_xyz` must point to `count * 3` consecutive `f64` values.
+/// - `r2` must point to `count` consecutive positive finite `f64` values.
+/// - `out_force_xyz` must point to `count * 3` writable `f64` values when `count > 0`.
+/// - `out_energy`, `out_virial`, and `out_stress` must be writable pointers; `out_stress`
+///   must point to nine `f64` values in row-major order.
+///
+/// # Return codes
+///
+/// - `0`: success.
+/// - `-1`: invalid pointers, non-finite parameters, non-positive distances, or a pair
+///   outside the cutoff.
+#[no_mangle]
+pub unsafe extern "C" fn lpmd_lennard_jones_batch(
+    rij_xyz: *const f64,
+    r2: *const f64,
+    count: usize,
+    sigma: f64,
+    epsilon: f64,
+    cutoff: f64,
+    out_force_xyz: *mut f64,
+    out_energy: *mut f64,
+    out_virial: *mut f64,
+    out_stress: *mut f64,
+) -> i32 {
+    if rij_xyz.is_null()
+        || r2.is_null()
+        || out_energy.is_null()
+        || out_virial.is_null()
+        || out_stress.is_null()
+        || (count > 0 && out_force_xyz.is_null())
+        || !sigma.is_finite()
+        || sigma <= 0.0
+        || !epsilon.is_finite()
+        || !cutoff.is_finite()
+        || cutoff <= 0.0
+    {
+        return -1;
+    }
+
+    let rij = unsafe { slice::from_raw_parts(rij_xyz, count * 3) };
+    let r2_values = unsafe { slice::from_raw_parts(r2, count) };
+
+    let sigma2 = sigma * sigma;
+    let cutoff2 = cutoff * cutoff;
+    if !sigma2.is_finite() || !cutoff2.is_finite() {
+        return -1;
+    }
+
+    let mut energy = 0.0;
+    let mut virial = 0.0;
+    let mut stress = [0.0_f64; 9];
+
+    for pair_index in 0..count {
+        let rr2 = r2_values[pair_index];
+        if !rr2.is_finite() || rr2 <= 0.0 || rr2 >= cutoff2 {
+            return -1;
+        }
+
+        let offset = pair_index * 3;
+        let rx = rij[offset];
+        let ry = rij[offset + 1];
+        let rz = rij[offset + 2];
+        if !rx.is_finite() || !ry.is_finite() || !rz.is_finite() {
+            return -1;
+        }
+
+        let r6 = (sigma2 / rr2).powi(3);
+        let r12 = r6 * r6;
+        let force_factor = -48.0 * (epsilon / rr2) * (r12 - 0.5 * r6);
+        let fx = rx * force_factor;
+        let fy = ry * force_factor;
+        let fz = rz * force_factor;
+
+        unsafe {
+            ptr::write(out_force_xyz.add(offset), fx);
+            ptr::write(out_force_xyz.add(offset + 1), fy);
+            ptr::write(out_force_xyz.add(offset + 2), fz);
+        }
+
+        energy += 4.0 * epsilon * (r12 - r6);
+        virial -= rx * fx + ry * fy + rz * fz;
+        stress[0] += -rx * fx;
+        stress[1] += -rx * fy;
+        stress[2] += -rx * fz;
+        stress[3] += -ry * fx;
+        stress[4] += -ry * fy;
+        stress[5] += -ry * fz;
+        stress[6] += -rz * fx;
+        stress[7] += -rz * fy;
+        stress[8] += -rz * fz;
+    }
+
+    unsafe {
+        ptr::write(out_energy, energy);
+        ptr::write(out_virial, virial);
+        for (index, value) in stress.iter().enumerate() {
+            ptr::write(out_stress.add(index), *value);
+        }
+    }
+
+    0
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{lpmd_build_neighbor_list_orthogonal, lpmd_histogram_summary};
+    use super::{
+        lpmd_build_neighbor_list_orthogonal, lpmd_histogram_summary, lpmd_lennard_jones_batch,
+    };
     use std::ptr;
 
     #[test]
@@ -477,5 +590,65 @@ mod tests {
 
         assert_eq!(status, -2);
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn computes_lennard_jones_batch_terms() {
+        let rij = [1.0_f64, 0.0, 0.0];
+        let r2 = [1.0_f64];
+        let mut forces = [0.0_f64; 3];
+        let mut energy = 0.0;
+        let mut virial = 0.0;
+        let mut stress = [0.0_f64; 9];
+
+        let status = unsafe {
+            lpmd_lennard_jones_batch(
+                rij.as_ptr(),
+                r2.as_ptr(),
+                1,
+                1.0,
+                1.0,
+                2.0,
+                forces.as_mut_ptr(),
+                &mut energy,
+                &mut virial,
+                stress.as_mut_ptr(),
+            )
+        };
+
+        assert_eq!(status, 0);
+        assert!((energy - 0.0).abs() < 1e-12);
+        assert!((forces[0] + 24.0).abs() < 1e-12);
+        assert_eq!(forces[1], 0.0);
+        assert_eq!(forces[2], 0.0);
+        assert!((virial - 24.0).abs() < 1e-12);
+        assert!((stress[0] - 24.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn rejects_lennard_jones_pairs_outside_cutoff() {
+        let rij = [3.0_f64, 0.0, 0.0];
+        let r2 = [9.0_f64];
+        let mut forces = [0.0_f64; 3];
+        let mut energy = 0.0;
+        let mut virial = 0.0;
+        let mut stress = [0.0_f64; 9];
+
+        let status = unsafe {
+            lpmd_lennard_jones_batch(
+                rij.as_ptr(),
+                r2.as_ptr(),
+                1,
+                1.0,
+                1.0,
+                2.0,
+                forces.as_mut_ptr(),
+                &mut energy,
+                &mut virial,
+                stress.as_mut_ptr(),
+            )
+        };
+
+        assert_eq!(status, -1);
     }
 }

--- a/plugins/lennardjones.cc
+++ b/plugins/lennardjones.cc
@@ -4,7 +4,16 @@
 
 #include "lennardjones.h"
 
+#include <lpmd/configuration.h>
+#include <runtime/runtime_context.h>
+
+#include <cmath>
 #include <iostream>
+#include <vector>
+
+#ifdef LPMD_ENABLE_RUST_HOTSPOTS
+#include <lpmd/rust_hotspots.h>
+#endif
 
 using namespace lpmd;
 
@@ -64,6 +73,103 @@ Vector LennardJones::pairForce(const Vector& r) const {
   double ff = -48.0e0 * (epsilon / rr2) * (r12 - 0.50e0 * r6);
   Vector fv = r * ff;
   return fv;
+}
+
+void LennardJones::UpdateForces(Configuration& conf) {
+#ifndef LPMD_ENABLE_RUST_HOTSPOTS
+  PairPotential::UpdateForces(conf);
+#else
+  const double forcefactor = conf.Context().session()["forcefactor"];
+  BasicParticleSet& atoms = conf.Atoms();
+  const long int n = atoms.Size();
+  energycache = 0.0;
+  double stress[3][3];
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j)
+      stress[i][j] = 0.0e0;
+  }
+  const double cutoff = GetCutoff();
+
+  double etmp = 0.0e0, tmpvir = 0.0e0;
+  std::vector<double> rij_buffer;
+  std::vector<double> r2_buffer;
+  std::vector<double> force_buffer;
+  std::vector<long int> neighbor_indices;
+
+  for (long i = 0; i < n; ++i) {
+    NeighborList nlist;
+    conf.GetCellManager().BuildNeighborList(conf, i, nlist, false, cutoff);
+    const long neighbor_count = nlist.Size();
+    rij_buffer.clear();
+    r2_buffer.clear();
+    neighbor_indices.clear();
+    rij_buffer.reserve(static_cast<std::size_t>(neighbor_count) * 3);
+    r2_buffer.reserve(static_cast<std::size_t>(neighbor_count));
+    neighbor_indices.reserve(static_cast<std::size_t>(neighbor_count));
+
+    for (long k = 0; k < neighbor_count; ++k) {
+      const AtomPair& nn = nlist[k];
+      if (AppliesTo(atoms[i].Z(), nn.j->Z()) && nn.r2 < cutoff * cutoff) {
+        rij_buffer.push_back(nn.rij[0]);
+        rij_buffer.push_back(nn.rij[1]);
+        rij_buffer.push_back(nn.rij[2]);
+        r2_buffer.push_back(nn.r2);
+        neighbor_indices.push_back(nn.j_index);
+      }
+    }
+
+    const std::size_t pair_count = r2_buffer.size();
+    if (pair_count == 0)
+      continue;
+
+    force_buffer.resize(pair_count * 3);
+    double batch_energy = 0.0;
+    double batch_virial = 0.0;
+    double batch_stress[9] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    const int status = lpmd_lennard_jones_batch(rij_buffer.data(), r2_buffer.data(), pair_count,
+                                                sigma, epsilon, cutoff, force_buffer.data(),
+                                                &batch_energy, &batch_virial, batch_stress);
+    if (status != 0) {
+      for (long k = 0; k < neighbor_count; ++k) {
+        const AtomPair& nn = nlist[k];
+        if (AppliesTo(atoms[i].Z(), nn.j->Z()) && nn.r2 < cutoff * cutoff) {
+          etmp += pairEnergy(sqrt(nn.r2));
+          Vector ff = pairForce(nn.rij);
+          atoms[i].Acceleration() += ff * (forcefactor / atoms[i].Mass());
+          nn.j->Acceleration() -= ff * (forcefactor / nn.j->Mass());
+          tmpvir -= Dot(nn.rij, ff);
+          for (int l = 0; l < 3; ++l) {
+            stress[0][l] += -(nn.rij)[0] * ff[l];
+            stress[1][l] += -(nn.rij)[1] * ff[l];
+            stress[2][l] += -(nn.rij)[2] * ff[l];
+          }
+        }
+      }
+      continue;
+    }
+
+    etmp += batch_energy;
+    tmpvir += batch_virial;
+    for (int row = 0; row < 3; ++row)
+      for (int col = 0; col < 3; ++col)
+        stress[row][col] += batch_stress[row * 3 + col];
+
+    for (std::size_t k = 0; k < pair_count; ++k) {
+      const Vector ff(force_buffer[k * 3], force_buffer[k * 3 + 1], force_buffer[k * 3 + 2]);
+      atoms[i].Acceleration() += ff * (forcefactor / atoms[i].Mass());
+      atoms[neighbor_indices[k]].Acceleration() -=
+          ff * (forcefactor / atoms[neighbor_indices[k]].Mass());
+    }
+  }
+
+  double& config_virial = conf.Virial();
+  energycache += etmp;
+  config_virial += tmpvir;
+  Matrix& config_stress = conf.StressTensor();
+  for (int p = 0; p < 3; p++)
+    for (int q = 0; q < 3; q++)
+      config_stress.Set(q, p, config_stress.Get(q, p) + stress[q][p]);
+#endif
 }
 
 // Esto se incluye para que el modulo pueda ser cargado dinamicamente

--- a/plugins/lennardjones.h
+++ b/plugins/lennardjones.h
@@ -12,12 +12,13 @@ class LennardJones : public lpmd::PairPotential, public lpmd::Plugin {
 public:
   // Metodos Generales
   LennardJones(std::string args);
-  ~LennardJones(){};
+  ~LennardJones() {};
   void ShowHelp() const;
 
   // Metodos Propios de modulo lennardjones
   double pairEnergy(const double& r) const;
   lpmd::Vector pairForce(const lpmd::Vector& r) const;
+  void UpdateForces(lpmd::Configuration& conf);
 
 private:
   double sigma, epsilon, cutoff;

--- a/plugins/minimumimage.cc
+++ b/plugins/minimumimage.cc
@@ -16,6 +16,11 @@
 using namespace lpmd;
 
 MinimumImageCellManager::MinimumImageCellManager(std::string args) : Plugin("minimumimage", "2.0") {
+#if defined(LPMD_ENABLE_RUST_HOTSPOTS) && !defined(_OPENMP)
+  rust_last_center_index = -1;
+  rust_cached_atom_count = 0;
+  rust_sequence_active = false;
+#endif
   ParamList& params = (*this);
   //
   DefineKeyword("cutoff", "0.0");
@@ -56,7 +61,17 @@ void MinimumImageCellManager::Show(std::ostream& os) const {
     os << "   No cutoff was defined." << '\n';
 }
 
-void MinimumImageCellManager::Reset() {}
+void MinimumImageCellManager::Reset() {
+#if defined(LPMD_ENABLE_RUST_HOTSPOTS) && !defined(_OPENMP)
+  rust_positions.clear();
+  rust_indices.clear();
+  rust_rij.clear();
+  rust_r2.clear();
+  rust_last_center_index = -1;
+  rust_cached_atom_count = 0;
+  rust_sequence_active = false;
+#endif
+}
 
 void MinimumImageCellManager::UpdateCell(Configuration& conf) {
   BasicCell& cell = conf.Cell();
@@ -115,6 +130,7 @@ void MinimumImageCellManager::BuildNeighborList(Configuration& conf, long i, Nei
   const long int n = atoms.Size();
 
   if (cell.IsOrthogonal() && i >= 0 && i < n) {
+#if defined(_OPENMP)
     std::vector<double> positions(static_cast<std::size_t>(n) * 3);
     for (long int atom_index = 0; atom_index < n; ++atom_index) {
       const Vector& position = atoms[atom_index].Position();
@@ -123,23 +139,54 @@ void MinimumImageCellManager::BuildNeighborList(Configuration& conf, long i, Nei
       positions[offset + 1] = position[1];
       positions[offset + 2] = position[2];
     }
+    const double* positions_data = positions.data();
+#else
+    const bool can_reuse_positions =
+        rust_sequence_active && rust_cached_atom_count == n && i == rust_last_center_index + 1;
+    if (!can_reuse_positions) {
+      rust_positions.resize(static_cast<std::size_t>(n) * 3);
+      for (long int atom_index = 0; atom_index < n; ++atom_index) {
+        const Vector& position = atoms[atom_index].Position();
+        const std::size_t offset = static_cast<std::size_t>(atom_index) * 3;
+        rust_positions[offset] = position[0];
+        rust_positions[offset + 1] = position[1];
+        rust_positions[offset + 2] = position[2];
+      }
+      rust_cached_atom_count = n;
+      rust_sequence_active = (i == 0);
+    }
+    const double* positions_data = rust_positions.data();
+#endif
 
     double cell_lengths[3] = {cell[0][0], cell[1][1], cell[2][2]};
     std::uint8_t periodic[3] = {static_cast<std::uint8_t>(cell.Periodicity(0)),
                                 static_cast<std::uint8_t>(cell.Periodicity(1)),
                                 static_cast<std::uint8_t>(cell.Periodicity(2))};
-    const std::size_t capacity =
-        full ? (n > 0 ? static_cast<std::size_t>(n - 1) : 0)
-             : (i + 1 < n ? static_cast<std::size_t>(n - i - 1) : 0);
+    const std::size_t capacity = full ? (n > 0 ? static_cast<std::size_t>(n - 1) : 0)
+                                      : (i + 1 < n ? static_cast<std::size_t>(n - i - 1) : 0);
+#if defined(_OPENMP)
     std::vector<std::size_t> indices(capacity);
     std::vector<double> rij(capacity * 3);
     std::vector<double> r2(capacity);
+    std::size_t* indices_data = capacity > 0 ? indices.data() : nullptr;
+    double* rij_data = capacity > 0 ? rij.data() : nullptr;
+    double* r2_data = capacity > 0 ? r2.data() : nullptr;
+#else
+    if (rust_indices.size() < capacity)
+      rust_indices.resize(capacity);
+    if (rust_rij.size() < capacity * 3)
+      rust_rij.resize(capacity * 3);
+    if (rust_r2.size() < capacity)
+      rust_r2.resize(capacity);
+    std::size_t* indices_data = capacity > 0 ? rust_indices.data() : nullptr;
+    double* rij_data = capacity > 0 ? rust_rij.data() : nullptr;
+    double* r2_data = capacity > 0 ? rust_r2.data() : nullptr;
+#endif
     std::size_t count = 0;
 
     const int status = lpmd_build_neighbor_list_orthogonal(
-        positions.data(), static_cast<std::size_t>(n), static_cast<std::size_t>(i), cell_lengths,
-        periodic, rcu, full ? 1 : 0, capacity > 0 ? indices.data() : nullptr,
-        capacity > 0 ? rij.data() : nullptr, capacity > 0 ? r2.data() : nullptr, capacity, &count);
+        positions_data, static_cast<std::size_t>(n), static_cast<std::size_t>(i), cell_lengths,
+        periodic, rcu, full ? 1 : 0, indices_data, rij_data, r2_data, capacity, &count);
 
     if (status == 0) {
       nlist.Clear();
@@ -147,17 +194,23 @@ void MinimumImageCellManager::BuildNeighborList(Configuration& conf, long i, Nei
       nn.i = &atoms[i];
       nn.i_index = i;
       for (std::size_t k = 0; k < count; ++k) {
-        const long int j = static_cast<long int>(indices[k]);
+        const long int j = static_cast<long int>(indices_data[k]);
         nn.j = &(atoms[j]);
         nn.j_index = j;
         const std::size_t offset = k * 3;
-        nn.rij = Vector(rij[offset], rij[offset + 1], rij[offset + 2]);
-        nn.r2 = r2[k];
+        nn.rij = Vector(rij_data[offset], rij_data[offset + 1], rij_data[offset + 2]);
+        nn.r2 = r2_data[k];
         nlist.Append(nn);
       }
+#if !defined(_OPENMP)
+      rust_last_center_index = i;
+#endif
       return;
     }
   }
+#if !defined(_OPENMP)
+  rust_sequence_active = false;
+#endif
 #endif
 
   BuildNeighborListCpp(conf, i, nlist, full, rcu);

--- a/plugins/minimumimage.h
+++ b/plugins/minimumimage.h
@@ -8,6 +8,13 @@
 #include <lpmd/cellmanager.h>
 #include <lpmd/plugin.h>
 
+#ifdef LPMD_ENABLE_RUST_HOTSPOTS
+#ifndef _OPENMP
+#include <cstddef>
+#include <vector>
+#endif
+#endif
+
 using namespace lpmd;
 
 class MinimumImageCellManager : public CellManager, public Plugin {
@@ -26,6 +33,16 @@ public:
 
 private:
   double rcut;
+
+#if defined(LPMD_ENABLE_RUST_HOTSPOTS) && !defined(_OPENMP)
+  std::vector<double> rust_positions;
+  std::vector<std::size_t> rust_indices;
+  std::vector<double> rust_rij;
+  std::vector<double> rust_r2;
+  long rust_last_center_index;
+  long rust_cached_atom_count;
+  bool rust_sequence_active;
+#endif
 };
 
 #endif


### PR DESCRIPTION
### Motivation
- Provide a vectorized Rust hotspot for Lennard-Jones computations to accelerate per-pair force/energy/virial/stress calculations and expose it to the C++ plugins via FFI. 
- Reduce overhead in orthogonal neighbor-list construction by reusing temporary buffers across sequential center indices when not using OpenMP. 

### Description
- Add `lpmd_lennard_jones_batch` to the Rust FFI header (`liblpmd/rust/include/lpmd/rust_hotspots.h`) and implement it in Rust (`liblpmd/rust/src/lib.rs`) with input validation, per-pair force writes, and accumulated energy/virial/stress outputs. 
- Add Rust unit tests for the new batch routine (`computes_lennard_jones_batch_terms` and `rejects_lennard_jones_pairs_outside_cutoff`) and include the symbol in the test module. 
- Update the `LennardJones` plugin (`plugins/lennardjones.cc` / `.h`) to call `lpmd_lennard_jones_batch` when `LPMD_ENABLE_RUST_HOTSPOTS` is defined, add `UpdateForces(Configuration&)` implementation that batches pairs, and keep the fallback to `PairPotential::UpdateForces` when hotspots are disabled. 
- Modify `MinimumImageCellManager` (`plugins/minimumimage.cc` / `.h`) to add cached buffers and sequence-tracking fields (only when `LPMD_ENABLE_RUST_HOTSPOTS` and not `_OPENMP`), clear them in `Reset()`, and use cached arrays or local vectors depending on OpenMP to call `lpmd_build_neighbor_list_orthogonal` with stable pointers. 
- Small API/formatting updates in headers and minor cleanup (destructors, includes). 

### Testing
- Ran Rust unit tests with `cargo test` in the Rust crate, which executed the existing histogram and neighbor-list tests plus the new `lpmd_lennard_jones_batch` tests, and they passed. 
- Built the C++ plugins with and without `LPMD_ENABLE_RUST_HOTSPOTS` to verify integration and plugin compilation, and the builds completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08ee8524708320827ec78047c4aba5)